### PR TITLE
Implement pod2pod

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,6 +19,26 @@
                 "--remote-uri",
                 "https://fjreifjeiorfjeiofjiorfjirefj.com"
             ]
+        },
+        {
+            "name": "Launch - pod2pod",
+            "type": "go",
+            "request": "launch",
+            "mode": "debug",
+            "program": "${workspaceFolder}",
+            "args": [
+                "pod2pod",
+                "--namespace-from",
+                "default",
+                "--pod-from",
+                "grafana",
+                "--namespace-to",
+                "kube-system",
+                "--pod-to",
+                "coredns",
+                "--port",
+                "53"
+            ]
         }
     ]
 }

--- a/cmd/pod2pod.go
+++ b/cmd/pod2pod.go
@@ -2,17 +2,72 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
+	"github.com/grafana/nethack/pkg"
 	"github.com/spf13/cobra"
 )
 
 func Pod2Pod() *Command {
-	return &Command{
+	cmd := &Command{
 		Command: &cobra.Command{
-			Use: "pod2pod",
-			Run: func(cmd *cobra.Command, args []string) {
-				fmt.Println("pod2pod not implemented yet")
-			},
+			Use: "pod2remote",
+			Run: Pod2PodExec,
 		},
 	}
+
+	cmd.Flags().String("namespace-from", "", "Namespace to test connections from.")
+	cmd.Flags().String("pod-from", "", "Pod regex to test connections from. The first pod that matches the regex will be used.")
+	cmd.Flags().String("namespace-to", "", "Namespace to test connections to.")
+	cmd.Flags().String("pod-to", "", "Pod regex to test connections to. The first pod that matches the regex will be used.")
+	cmd.Flags().String("port", "", "Target port to connect to.")
+
+	return cmd
+}
+
+func Pod2PodExec(cmd *cobra.Command, args []string) {
+	parseFlags(cmd, args)
+	podRegexFrom, err := cmd.Flags().GetString("pod-from")
+	if err != nil {
+		fmt.Println("pod-from must be specified", err)
+		return
+	}
+
+	namespaceFrom, err := cmd.Flags().GetString("namespace-from")
+	if err != nil {
+		fmt.Println("namespace-from must be specified", err)
+		return
+	}
+
+	podFrom, _ := getPodForWorkload(cmd.Context(), podRegexFrom, namespaceFrom)
+	command := []string{"nc"}
+
+	port, err := cmd.Flags().GetString("port")
+	if err != nil || port == "" {
+		fmt.Println("--port must be specified", err)
+		os.Exit(3)
+	}
+
+	podRegexTo, err := cmd.Flags().GetString("pod-to")
+	if err != nil {
+		fmt.Println("pod-to must be specified", err)
+		return
+	}
+
+	namespaceTo, err := cmd.Flags().GetString("namespace-to")
+	if err != nil {
+		fmt.Println("namespace-to must be specified", err)
+		return
+	}
+
+	podTo, _ := getPodForWorkload(cmd.Context(), podRegexTo, namespaceTo)
+
+	arguments := []string{"-w", "3", "-z", podTo.Status.PodIP, port}
+	netshootifiedPod, ephemeralContainerName, err := pkg.LaunchEphemeralContainer(podFrom, command, arguments)
+	if err != nil {
+		fmt.Println("Error launching ephemeral container.", err)
+		os.Exit(3)
+	}
+	exitStatus := pkg.PollEphemeralContainerStatus(netshootifiedPod, ephemeralContainerName)
+	os.Exit(int(exitStatus))
 }

--- a/interactive/bubbletea.go
+++ b/interactive/bubbletea.go
@@ -1,6 +1,7 @@
 package interactive
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"strings"
@@ -9,6 +10,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/grafana/nethack/pkg"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 const listHeight = 14
@@ -103,11 +105,11 @@ func (m model) View() string {
 
 func initialModel() model {
 	k := pkg.GetKubernetes()
-	namespaces, err := k.Client.CoreV1().Namespaces().List(context.TODO(), metav1.ListOptions{})
+	ns, _ := k.Client.CoreV1().Namespaces().List(context.TODO(), metav1.ListOptions{})
 
 	var namespaceNames []list.Item
-	for _, name := range ns {
-		namespaceNames = append(namespaceNames, item(name))
+	for _, name := range ns.Items {
+		namespaceNames = append(namespaceNames, item(name.Name))
 	}
 
 	const defaultWidth = 20


### PR DESCRIPTION
- fix compiler errors in interactive package
- refactor getPodForWorkload to take pod details rather than parsing them from the cmd (note: this function should be moved into pkg.Kubernetes)
- implement pod2pod functionality