### PR TITLE
fix: Make the Kubernetes package mockable

### DIFF
--- a/pkg/kubernetes.go
+++ b/pkg/kubernetes.go
@@ -23,7 +23,7 @@ import (
 )
 
 var (
-	instance *Kubernetes = &Kubernetes{}
+	Instance *Kubernetes = &Kubernetes{}
 )
 
 type Kubernetes struct {
@@ -44,28 +44,28 @@ func FetchKubeConfig() {
 		}
 	}
 
-	instance.Config = config
+	Instance.Config = config
 }
 
 func MakeKubeClient() {
 	// create the clientset
-	client, err := kubernetes.NewForConfig(instance.Config)
+	client, err := kubernetes.NewForConfig(Instance.Config)
 	if err != nil {
 		panic(err.Error())
 	}
 
-	instance.Client = client
+	Instance.Client = client
 }
 
 func GetKubernetes() *Kubernetes {
-	if instance.Config == nil {
+	if Instance.Config == nil {
 		FetchKubeConfig()
 	}
-	if instance.Client == nil {
+	if Instance.Client == nil {
 		MakeKubeClient()
 	}
 
-	return instance
+	return Instance
 }
 
 func GetNamespaces() []string {


### PR DESCRIPTION
Exposing the Instance will allow us to replace the client with a fake. This will enable us to test with mocks!
relates-to: https://github.com/grafana/nethax/issues/17