### PR TITLE
feat: Add support for docker and expect fail

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM golang:1.22-alpine AS build
+
+WORKDIR /
+
+COPY [".", "."]
+RUN ["go", "mod", "download"]
+
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags='-w -s -extldflags "-static"' -a -o nethax .
+
+FROM scratch
+
+COPY --from=build /nethax /nethax
+
+ENTRYPOINT ["/nethax"]

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Possible exit codes are:
 Nethack will perform the test and then return an exit code. Possible exit codes are:
 ```
 exit 0 - success
-exit 1 - connection not established
+exit 1 - failure
 exit 2 - timeout exceeded
 exit 3 - nethax error
 ... [TODO - clean this up]
@@ -29,7 +29,7 @@ exit 3 - nethax error
 ### Global Options (TODO)
 ```
     --timeout [SECONDS] - length of time to wait for establishing a TCP connection
-    --context [NAME]    - connect to specified context name from kubeconfig
+    --expect-fail       - when set, it is expected that sockets will not connect; nethax will exit 0
 ```
 
 ### pod-to-pod

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -28,9 +28,15 @@ type Command struct {
 	*cobra.Group
 }
 
+func addSharedFlags(cmd *Command) {
+	cmd.Flags().Int("timeout", 5, "Timeout for connections. Socket must connect successfully before this deadline elapses.")
+	cmd.Flags().Bool("expect-fail", false, "Exit 0 on connection failure. Useful for tests where connections are expected to fail.")
+}
+
 // AddCommand adds child commands and adds child commands for cobra as well.
 func (c *Command) AddCommand(commands ...*Command) {
 	for _, cmd := range commands {
+		addSharedFlags(cmd)
 		c.Command.AddCommand(cmd.Command)
 	}
 }

--- a/cmd/pod2pod.go
+++ b/cmd/pod2pod.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strconv"
 
 	"github.com/grafana/nethax/pkg"
 	"github.com/spf13/cobra"
@@ -11,7 +12,7 @@ import (
 func Pod2Pod() *Command {
 	cmd := &Command{
 		Command: &cobra.Command{
-			Use: "pod2remote",
+			Use: "pod2pod",
 			Run: Pod2PodExec,
 		},
 	}
@@ -29,45 +30,50 @@ func Pod2PodExec(cmd *cobra.Command, args []string) {
 	parseFlags(cmd, args)
 	podRegexFrom, err := cmd.Flags().GetString("pod-from")
 	if err != nil {
-		fmt.Println("pod-from must be specified", err)
+		fmt.Println("--pod-from must be specified", err)
 		return
 	}
-
 	namespaceFrom, err := cmd.Flags().GetString("namespace-from")
 	if err != nil {
-		fmt.Println("namespace-from must be specified", err)
+		fmt.Println("--namespace-from must be specified", err)
 		return
 	}
-
-	podFrom, _ := getPodForWorkload(cmd.Context(), podRegexFrom, namespaceFrom)
-	command := []string{"nc"}
-
 	port, err := cmd.Flags().GetString("port")
 	if err != nil || port == "" {
 		fmt.Println("--port must be specified", err)
 		os.Exit(3)
 	}
-
 	podRegexTo, err := cmd.Flags().GetString("pod-to")
 	if err != nil {
-		fmt.Println("pod-to must be specified", err)
+		fmt.Println("--pod-to must be specified", err)
 		return
 	}
-
 	namespaceTo, err := cmd.Flags().GetString("namespace-to")
 	if err != nil {
-		fmt.Println("namespace-to must be specified", err)
+		fmt.Println("--namespace-to must be specified", err)
 		return
 	}
+	timeout, err := cmd.Flags().GetInt("timeout")
+	if err != nil {
+		fmt.Println("--timeout is invalid", "stacktrace:", err)
+		os.Exit(3)
+	}
+	expectFail, err := cmd.Flags().GetBool("expect-fail")
+	if err != nil {
+		fmt.Println("--expect-fail is invalid", "stacktrace:", err)
+		os.Exit(3)
+	}
+	podFrom, _ := getPodForWorkload(cmd.Context(), podRegexFrom, namespaceFrom)
+	command := []string{"nc"}
 
 	podTo, _ := getPodForWorkload(cmd.Context(), podRegexTo, namespaceTo)
 
-	arguments := []string{"-w", "3", "-z", podTo.Status.PodIP, port}
+	arguments := []string{"-w", strconv.Itoa(timeout), "-z", podTo.Status.PodIP, port}
 	netshootifiedPod, ephemeralContainerName, err := pkg.LaunchEphemeralContainer(podFrom, command, arguments)
 	if err != nil {
 		fmt.Println("Error launching ephemeral container.", err)
 		os.Exit(3)
 	}
 	exitStatus := pkg.PollEphemeralContainerStatus(netshootifiedPod, ephemeralContainerName)
-	os.Exit(int(exitStatus))
+	os.Exit(pkg.ExitNethax(int(exitStatus), expectFail))
 }

--- a/example/Job.yaml
+++ b/example/Job.yaml
@@ -1,0 +1,72 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nethax
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: nethax
+rules:
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get", "watch", "list"]
+- apiGroups: [""]
+  resources: ["pods/ephemeralcontainers"]
+  verbs: ["patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: nethax
+subjects:
+- kind: ServiceAccount
+  name: nethax
+roleRef:
+  kind: ClusterRole
+  name: nethax
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: nethax
+spec:
+  template:
+    spec:
+      serviceAccountName: nethax
+      containers:
+      # connecting to grafana.com, failure not expected, exit 0
+      - name: nethax-grafana-success
+        image: nethax:v0.0.5
+        command: ["/nethax", "pod2remote", "--pod-from=nginx", "--namespace-from=default", "--remote-uri=https://grafana.com"]
+      # connecting to grafana.com, failure is expected, exit 1 
+      - name: nethax-grafana-fail
+        image: nethax:v0.0.5
+        command: ["/nethax", "pod2remote", "--pod-from=nginx", "--namespace-from=default", "--expect-fail", "--remote-uri=https://grafana.com"]
+      # connecting to grafanyaa.com, failure is expected, exit 0 
+      - name: nethax-grafanyaa-success
+        image: nethax:v0.0.5
+        command: ["/nethax", "pod2remote", "--pod-from=nginx", "--namespace-from=default", "--expect-fail", "--remote-uri=https://grafanyaa.com"]
+      # connecting to grafanyaa.com, failure not expected, exit 1 
+      - name: nethax-grafanyaa-fail
+        image: nethax:v0.0.5
+        command: ["/nethax", "pod2remote", "--pod-from=nginx", "--namespace-from=default", "--remote-uri=https://grafanyaa.com"]
+      # connecting to nginx from nginx, failure not expected, exit 0
+      - name: nethax-nginx-80-success
+        image: nethax:v0.0.5
+        command: ["/nethax", "pod2pod", "--pod-from=nginx", "--namespace-from=default", "--pod-to=nginx", "--namespace-to=default", "--port=80"]
+      # connecting to nginx from nginx, failure is expected, exit 1 
+      - name: nethax-nginx-80-fail
+        image: nethax:v0.0.5
+        command: ["/nethax", "pod2pod", "--pod-from=nginx", "--namespace-from=default", "--expect-fail", "--pod-to=nginx", "--namespace-to=default", "--port=80"]
+      # connecting to nginx from nginx, failure is expected, exit 0 
+      - name: nethax-nginx-42-success
+        image: nethax:v0.0.5
+        command: ["/nethax", "pod2pod", "--pod-from=nginx", "--namespace-from=default", "--expect-fail", "--pod-to=nginx", "--namespace-to=default", "--port=42"]
+      # connecting to nginx from nginx, failure not expected, exit 1 
+      - name: nethax-nginx-42-fail
+        image: nethax:v0.0.5
+        command: ["/nethax", "pod2pod", "--pod-from=nginx", "--namespace-from=default", "--pod-to=nginx", "--namespace-to=default", "--port=42"]
+      restartPolicy: Never
+  backoffLimit: 4

--- a/pkg/nethax.go
+++ b/pkg/nethax.go
@@ -1,0 +1,16 @@
+package pkg
+
+func ExitNethax(exitStatus int, expectFail bool) int {
+	if expectFail { // we expect connections to fail
+		if exitStatus == 0 {
+			exitStatus = 1 // connection succeeded when expected to fail
+		} else {
+			exitStatus = 0 // connection failed when expected to fail
+		}
+	}
+	if exitStatus > 1 {
+		exitStatus = 1 // normalize other failed exit codes to 1
+	}
+
+	return exitStatus
+}


### PR DESCRIPTION
- Dockerfile builds an app image from scratch
- New --expect-fail global option expects connections to fail
- exit codes normalized to 0 (expected socket connection result) and 1 (unexpected socket connection result)

Fixes #18 <3
