### PR TITLE
fix: Probe binary should be output into bin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ build-nethax: deps-nethax
 	@cd ${DIR_NETHAX} && go build -o "$(CUR_DIR)/bin"
 
 build-probe: deps-probe
-	@cd ${DIR_PROBE} && go build
+	@cd ${DIR_PROBE} && go build -o "$(CUR_DIR)/bin"
 
 test:
 	@go test ./...


### PR DESCRIPTION
The `.gitignore` expects that the probe binary is located in the bin directory
