### PR TITLE
chore: Add docker build for probe

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,12 @@ FROM golang:1.22-alpine AS build
 WORKDIR /
 
 COPY [".", "."]
-RUN ["go", "mod", "download"]
+RUN cd cmd/nethax && go mod download
 
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags='-w -s -extldflags "-static"' -a -o nethax .
+RUN cd cmd/nethax && CGO_ENABLED=0 GOOS=linux go build -ldflags='-w -s -extldflags "-static"' -a -o nethax .
 
 FROM scratch
 
-COPY --from=build /nethax /nethax
+COPY --from=build /cmd/nethax/nethax /nethax
 
 ENTRYPOINT ["/nethax"]

--- a/Dockerfile-probe
+++ b/Dockerfile-probe
@@ -1,0 +1,14 @@
+FROM golang:1.22-alpine AS build
+
+WORKDIR /
+
+COPY [".", "."]
+RUN cd cmd/probe && go mod download
+
+RUN cd cmd/probe && CGO_ENABLED=0 GOOS=linux go build -ldflags='-w -s -extldflags "-static"' -a -o probe .
+
+FROM scratch
+
+COPY --from=build /cmd/probe/probe /probe
+
+ENTRYPOINT ["/probe"]

--- a/cmd/probe/main.go
+++ b/cmd/probe/main.go
@@ -55,5 +55,12 @@ func testConnectivity(cmd *cobra.Command, args []string) {
 		fmt.Println("Encountered error trying to close TCP connection:", err)
 		os.Exit(1)
 	}
-	os.Exit(0)
+
+	if !expectFail {
+		fmt.Println("Failure not expected, exiting cleanly.")
+		os.Exit(0)
+	} else {
+		fmt.Println("Failure expected, exiting with error.")
+		os.Exit(1)
+	}
 }


### PR DESCRIPTION
Add a docker container for the probe so we can use it in nethax (relates-to: #33)

Also noticed some errors with the nethax container build after splitting the project.

Also fixed a bug in the `--expect-failure` flag - it should exit 1 if no failure occurs when failure is expected.