### PR TITLE
fix: Use go 1.24 Testing Contexts in tests

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/nethax
 
-go 1.21.5
+go 1.24.2
 
 require (
 	github.com/goccy/go-yaml v1.17.1

--- a/pkg/kubernetes/kubernetes_test.go
+++ b/pkg/kubernetes/kubernetes_test.go
@@ -1,7 +1,6 @@
 package kubernetes
 
 import (
-	"context"
 	"reflect"
 	"testing"
 
@@ -22,17 +21,17 @@ func TestGetPods(t *testing.T) {
 	expected := []string{"grafanyaa"}
 	namespace := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{Name: expected[0]}}
-	k.Client.CoreV1().Namespaces().Create(context.TODO(), namespace, metav1.CreateOptions{})
+	k.Client.CoreV1().Namespaces().Create(t.Context(), namespace, metav1.CreateOptions{})
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: expected[0],
 			Name:      expected[0],
 		},
 	}
-	k.Client.CoreV1().Pods(expected[0]).Create(context.TODO(), pod, metav1.CreateOptions{})
+	k.Client.CoreV1().Pods(expected[0]).Create(t.Context(), pod, metav1.CreateOptions{})
 
 	// execute
-	actual := GetPods(context.TODO(), expected[0])
+	actual := GetPods(t.Context(), expected[0])
 
 	// assert
 	if !reflect.DeepEqual(actual, expected) {
@@ -40,17 +39,18 @@ func TestGetPods(t *testing.T) {
 	}
 
 	// clean up
-	k.Client.CoreV1().Pods(expected[0]).Delete(context.TODO(), expected[0], metav1.DeleteOptions{})
-	k.Client.CoreV1().Namespaces().Delete(context.TODO(), expected[0], metav1.DeleteOptions{})
+	k.Client.CoreV1().Pods(expected[0]).Delete(t.Context(), expected[0], metav1.DeleteOptions{})
+	k.Client.CoreV1().Namespaces().Delete(t.Context(), expected[0], metav1.DeleteOptions{})
 }
 
 func TestLaunchEphemeralContainer(t *testing.T) {
+
 	// prepare
 	k := setup()
 	name := "grafanyaa"
 	namespace := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{Name: name}}
-	k.Client.CoreV1().Namespaces().Create(context.TODO(), namespace, metav1.CreateOptions{})
+	k.Client.CoreV1().Namespaces().Create(t.Context(), namespace, metav1.CreateOptions{})
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: name,
@@ -62,10 +62,10 @@ func TestLaunchEphemeralContainer(t *testing.T) {
 			},
 		},
 	}
-	k.Client.CoreV1().Pods(name).Create(context.TODO(), pod, metav1.CreateOptions{})
+	k.Client.CoreV1().Pods(name).Create(t.Context(), pod, metav1.CreateOptions{})
 
 	// execute
-	actual, _, _ := LaunchEphemeralContainer(context.TODO(), pod, []string{"nyaa"}, []string{"rawr"})
+	actual, _, _ := LaunchEphemeralContainer(t.Context(), pod, []string{"nyaa"}, []string{"rawr"})
 
 	// assert
 	if len(actual.Spec.EphemeralContainers) != 1 {
@@ -73,6 +73,6 @@ func TestLaunchEphemeralContainer(t *testing.T) {
 	}
 
 	// clean up
-	k.Client.CoreV1().Pods(name).Delete(context.TODO(), name, metav1.DeleteOptions{})
-	k.Client.CoreV1().Namespaces().Delete(context.TODO(), name, metav1.DeleteOptions{})
+	k.Client.CoreV1().Pods(name).Delete(t.Context(), name, metav1.DeleteOptions{})
+	k.Client.CoreV1().Namespaces().Delete(t.Context(), name, metav1.DeleteOptions{})
 }


### PR DESCRIPTION
https://tip.golang.org/doc/go1.24#testingpkgtesting

Go 1.24 introduces T.Context() which can be used in tests instead of context.TODO().

This PR makes use of those. It also updates the go.mod version to 1.24.

Can be tested with `make test`.
