### PR TITLE
fix: Example test plan had a typo in it

### DIFF
--- a/example/OtelDemoTestPlan.yaml
+++ b/example/OtelDemoTestPlan.yaml
@@ -28,5 +28,5 @@ testPlan:
     - name: "TCP service call"
       endpoint: "fake-service.fake.svc.cluster.local:9001"
       type: tcp
-      expectFail: false # TCP connection failure is expected; useful to test network policies
+      expectFail: true # TCP connection failure is expected; useful to test network policies
       timeout: 3s


### PR DESCRIPTION
I forgot to fix this; I was testing to ensure that the tests would fail properly, but I think the example should have all passing tests.
