### PR TITLE
fix: Refactor kubernetes package

### DIFF
--- a/cmd/runner/executetest.go
+++ b/cmd/runner/executetest.go
@@ -124,7 +124,7 @@ func executeTest(ctx context.Context, plan *TestPlan) bool {
 	indent("Description: "+plan.Description, 0)
 	fmt.Println()
 
-	k := kubernetes.GetKubernetes()
+	k := kubernetes.GetKubernetes("")
 	allTestsPassed := true
 
 	for _, target := range plan.TestTargets {
@@ -224,7 +224,7 @@ func executeTest(ctx context.Context, plan *TestPlan) bool {
 				}
 
 				// Launch ephemeral container to execute the test
-				probedPod, probeContainerName, err := kubernetes.LaunchEphemeralContainer(ctx, pod, command, arguments)
+				probedPod, probeContainerName, err := k.LaunchEphemeralContainer(ctx, pod, command, arguments)
 				if err != nil {
 					indent(fmt.Sprintf("Error: Failed to launch ephemeral probe container: %v", err), 3)
 					fmt.Println()
@@ -233,7 +233,7 @@ func executeTest(ctx context.Context, plan *TestPlan) bool {
 				}
 
 				// Wait for the test to complete and get the exit status
-				exitStatus := kubernetes.PollEphemeralContainerStatus(ctx, probedPod, probeContainerName)
+				exitStatus := k.PollEphemeralContainerStatus(ctx, probedPod, probeContainerName)
 
 				// Check if the test passed based on the probe's exit status
 				if exitStatus == 0 {

--- a/pkg/kubernetes/kubernetes_test.go
+++ b/pkg/kubernetes/kubernetes_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func setup() *Kubernetes {
-	k := GetKubernetes()
+	k := GetKubernetes("")
 	k.Client = testClient.NewSimpleClientset()
 	return k
 }
@@ -31,7 +31,7 @@ func TestGetPods(t *testing.T) {
 	k.Client.CoreV1().Pods(expected[0]).Create(t.Context(), pod, metav1.CreateOptions{})
 
 	// execute
-	actual := GetPods(t.Context(), expected[0])
+	actual := k.GetPods(t.Context(), expected[0])
 
 	// assert
 	if !reflect.DeepEqual(actual, expected) {
@@ -65,7 +65,7 @@ func TestLaunchEphemeralContainer(t *testing.T) {
 	k.Client.CoreV1().Pods(name).Create(t.Context(), pod, metav1.CreateOptions{})
 
 	// execute
-	actual, _, _ := LaunchEphemeralContainer(t.Context(), pod, []string{"nyaa"}, []string{"rawr"})
+	actual, _, _ := k.LaunchEphemeralContainer(t.Context(), pod, []string{"nyaa"}, []string{"rawr"})
 
 	// assert
 	if len(actual.Spec.EphemeralContainers) != 1 {


### PR DESCRIPTION
The Kubernetes package was built during a hackathon and was done quickly.

This refactors the package to:
- Attach methods to the Kubernetes object rather than use static methods (avoid duplicate calls to GetKubernetes)
- Allow Kubeconfig to be overridden, load from default kubeconfig path without hard coding
- Accept a context if given (currently not configurable by flag; will do in a follow up PR to refactor flags)

You can test this by:
```Console
k --context kind-kind create ns otel-demo
k --context kind-kind create cm -n otel-demo grafana-dashboards
k --context kind-kind replace --namespace otel-demo -f https://raw.githubusercontent.com/open-telemetry/opentelemetry-demo/main/kubernetes/opentelemetry-demo.yaml

make clean test build docker
[...]
./bin/runner execute-test -f example/OtelDemoTestPlan.yaml
```
