### PR TITLE
fix: Refactor probe flags

### DIFF
--- a/cmd/probe/main.go
+++ b/cmd/probe/main.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/grafana/nethax/pkg/common"
+	pf "github.com/grafana/nethax/pkg/probeflags"
 )
 
 var (
@@ -18,11 +19,11 @@ var (
 )
 
 func main() {
-	flag.StringVar(&url, "url", "", "URL or host:port to connect to")
-	flag.DurationVar(&timeout, "timeout", 5*time.Second, "Timeout value (e.g. 5s, 1m)")
-	flag.IntVar(&expectedStatus, "expected-status", 200, "Expected HTTP status code (0 for connection failure)")
-	flag.StringVar(&testType, "type", "http", "Type of test (http or tcp)")
-	flag.BoolVar(&expectFail, "expect-fail", false, "Whether the test is expected to fail (TCP tests only)")
+	flag.StringVar(&url, pf.ArgUrl, "", "URL or host:port to connect to")
+	flag.DurationVar(&timeout, pf.ArgTimeout, 5*time.Second, "Timeout value (e.g. 5s, 1m)")
+	flag.IntVar(&expectedStatus, pf.ArgExpectedStatus, 200, "Expected HTTP status code (0 for connection failure)")
+	flag.StringVar(&testType, pf.ArgType, pf.TestTypeHTTP, "Type of test (http or tcp)")
+	flag.BoolVar(&expectFail, pf.ArgExpectFail, false, "Whether the test is expected to fail (TCP tests only)")
 	flag.Parse()
 
 	if url == "" {

--- a/cmd/probe/main.go
+++ b/cmd/probe/main.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/grafana/nethax/pkg/common"
+	"github.com/grafana/nethax/pkg/probeflags"
 	pf "github.com/grafana/nethax/pkg/probeflags"
 )
 
@@ -28,15 +29,19 @@ func main() {
 
 	if url == "" {
 		fmt.Println("Error: URL must be specified")
-		common.ExitFailure()
+		common.ExitConfigError()
 	}
 
 	var probe Probe
 
-	if testType == "tcp" {
+	switch testType {
+	case probeflags.TestTypeTCP:
 		probe = NewTCPProbe(url, expectFail)
-	} else {
+	case probeflags.TestTypeHTTP:
 		probe = NewHTTPProbe(url, expectedStatus)
+	default:
+		fmt.Println("Error: Invalid test type: ", testType)
+		common.ExitConfigError()
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)

--- a/cmd/probe/main.go
+++ b/cmd/probe/main.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/grafana/nethax/pkg/common"
-	"github.com/grafana/nethax/pkg/probeflags"
 	pf "github.com/grafana/nethax/pkg/probeflags"
 )
 
@@ -20,7 +19,7 @@ var (
 )
 
 func main() {
-	flag.StringVar(&url, pf.ArgUrl, "", "URL or host:port to connect to")
+	flag.StringVar(&url, pf.ArgURL, "", "URL or host:port to connect to")
 	flag.DurationVar(&timeout, pf.ArgTimeout, 5*time.Second, "Timeout value (e.g. 5s, 1m)")
 	flag.IntVar(&expectedStatus, pf.ArgExpectedStatus, 200, "Expected HTTP status code (0 for connection failure)")
 	flag.StringVar(&testType, pf.ArgType, pf.TestTypeHTTP, "Type of test (http or tcp)")
@@ -35,9 +34,9 @@ func main() {
 	var probe Probe
 
 	switch testType {
-	case probeflags.TestTypeTCP:
+	case pf.TestTypeTCP:
 		probe = NewTCPProbe(url, expectFail)
-	case probeflags.TestTypeHTTP:
+	case pf.TestTypeHTTP:
 		probe = NewHTTPProbe(url, expectedStatus)
 	default:
 		fmt.Println("Error: Invalid test type: ", testType)

--- a/cmd/runner/executetest.go
+++ b/cmd/runner/executetest.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/grafana/nethax/pkg/common"
 	"github.com/grafana/nethax/pkg/kubernetes"
+	pf "github.com/grafana/nethax/pkg/probeflags"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
 )
@@ -119,15 +120,15 @@ func executeTest(ctx context.Context, k *kubernetes.Kubernetes, plan *TestPlan) 
 				// Prepare the test command
 				command := []string{"/probe"}
 				arguments := []string{
-					"--url", test.Endpoint,
-					"--timeout", test.Timeout.String(),
-					"--expected-status", strconv.Itoa(test.StatusCode),
+					pf.Flagify(pf.ArgUrl), test.Endpoint,
+					pf.Flagify(pf.ArgTimeout), test.Timeout.String(),
+					pf.Flagify(pf.ArgExpectedStatus), strconv.Itoa(test.StatusCode),
 				}
 
-				if test.Type == "tcp" {
-					arguments = append(arguments, "--type", "tcp")
+				if test.Type == pf.TestTypeTCP {
+					arguments = append(arguments, pf.Flagify(pf.ArgType), pf.TestTypeTCP)
 					if test.ExpectFail {
-						arguments = append(arguments, "--expect-fail")
+						arguments = append(arguments, pf.Flagify(pf.ArgExpectFail))
 					}
 				}
 

--- a/cmd/runner/executetest.go
+++ b/cmd/runner/executetest.go
@@ -120,7 +120,7 @@ func executeTest(ctx context.Context, k *kubernetes.Kubernetes, plan *TestPlan) 
 				// Prepare the test command
 				command := []string{"/probe"}
 				arguments := []string{
-					pf.Flagify(pf.ArgUrl), test.Endpoint,
+					pf.Flagify(pf.ArgURL), test.Endpoint,
 					pf.Flagify(pf.ArgTimeout), test.Timeout.String(),
 					pf.Flagify(pf.ArgExpectedStatus), strconv.Itoa(test.StatusCode),
 				}

--- a/pkg/probeflags/probeflags.go
+++ b/pkg/probeflags/probeflags.go
@@ -4,7 +4,7 @@ import "fmt"
 
 // Probe arguments -- can be Flagified
 const (
-	ArgUrl            = "url"
+	ArgURL            = "url"
 	ArgTimeout        = "timeout"
 	ArgExpectedStatus = "expected-status"
 	ArgExpectFail     = "expect-fail"

--- a/pkg/probeflags/probeflags.go
+++ b/pkg/probeflags/probeflags.go
@@ -1,0 +1,21 @@
+package probeflags
+
+import "fmt"
+
+// Probe arguments -- can be Flagified
+const (
+	ArgUrl            = "url"
+	ArgTimeout        = "timeout"
+	ArgExpectedStatus = "expected-status"
+	ArgExpectFail     = "expect-fail"
+	ArgType           = "type"
+)
+
+func Flagify(flag string) string {
+	return fmt.Sprintf("--%s", flag)
+}
+
+const (
+	TestTypeTCP  = "tcp"
+	TestTypeHTTP = "http"
+)

--- a/pkg/probeflags/probeflags_test.go
+++ b/pkg/probeflags/probeflags_test.go
@@ -15,7 +15,7 @@ func TestFlagify(t *testing.T) {
 	flag.Parse()
 
 	if !test {
-		t.Errorf("Expected --test to be set, go these args: %v", os.Args)
+		t.Errorf("Expected --test to be set, got these args: %v", os.Args)
 	}
 
 }

--- a/pkg/probeflags/probeflags_test.go
+++ b/pkg/probeflags/probeflags_test.go
@@ -1,0 +1,21 @@
+package probeflags
+
+import (
+	"flag"
+	"os"
+	"testing"
+)
+
+func TestFlagify(t *testing.T) {
+	testArg := "test"
+	var test bool
+	flag.BoolVar(&test, testArg, true, "Testing")
+	flagified := Flagify(testArg)
+	os.Args = []string{flagified}
+	flag.Parse()
+
+	if !test {
+		t.Errorf("Expected --test to be set, go these args: %v", os.Args)
+	}
+
+}


### PR DESCRIPTION
The probe flags are defined in `cmd/probe` and then used in `cmd/runner` -- this coupling is implicit and error prone.

This refactor pulls the probe flag strings out into a common package and defines a function to turn the strings into parseable flags. You can execute tests for this with `make test`.
