### PR TITLE
fix: Improve Contributor Experience

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+# Developer Setup
+
+Ensure you have `kubectl`, `kind`, and some kind of `docker` command installed.
+
+You can initialize a new kind cluster for testing and run the example test plan against it using this command:
+```Console
+# make kind-init-oteldemo run-example-test-plan
+```
+
+This make target will create new containers of the runner and the probe and upload them to your kind cluster:
+```Console
+# make docker
+```
+
+## Running the OtelDemo Example Test Plan
+The example test plan depends on the OtelDemo app, which is a comprehensive demonstration of a decently sized cloud-native application.
+
+The easiest way to install this is with `kubectl apply`:
+https://opentelemetry.io/docs/demo/kubernetes-deployment/#install-using-kubectl
+
+Once you've installed the OpenTelemetry Demo, you can execute the example test plan with the runner:
+```
+make run-example-test-plan
+```
+
+## TODO: Implement Kyverno E2E Testing
+This would automate the test process to make developer onboarding easier.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Developer Setup
 
-Ensure you have `kubectl`, `kind`, and some kind of `docker` command installed.
+Ensure you have `go`, `kubectl`, `kind`, and some kind of `docker` command installed.
 
 You can initialize a new kind cluster for testing and run the example test plan against it using this command:
 ```Console
@@ -22,6 +22,3 @@ Once you've installed the OpenTelemetry Demo, you can execute the example test p
 ```
 make run-example-test-plan
 ```
-
-## TODO: Implement Kyverno E2E Testing
-This would automate the test process to make developer onboarding easier.

--- a/Dockerfile-probe
+++ b/Dockerfile-probe
@@ -1,5 +1,4 @@
-# Build stage
-FROM golang:1.24-alpine AS builder
+FROM golang:1.24-alpine AS build
 
 WORKDIR /
 
@@ -11,16 +10,14 @@ RUN ["go", "mod", "download"]
 
 # Build the probe binary
 ARG PROBE_VERSION
-RUN ["env", "CGO_ENABLED=0", "GOOS=linux", "go", "build", "-ldflags=-w -s -extldflags '-static' -X 'github.com/grafana/nethax/pkg/kubernetes.ProbeImageVersion=${PROBE_VERSION}'", "-a", "-o", "/probe", "./cmd/probe"]
+RUN env CGO_ENABLED=0 GOOS=linux go build -ldflags="-w -s -extldflags '-static' -X ${PROBE_VERSION}" -a -o /probe ./cmd/probe
 
-# Final stage
 FROM scratch
 
-# Copy the binary from builder
-COPY --from=builder /probe /probe
+COPY --from=build /probe /probe
 
-# Copy CA certificates from builder
-COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+# Copy CA certificates from build
+COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
 
 # Set the entrypoint
 ENTRYPOINT ["/probe"] 

--- a/Dockerfile-runner
+++ b/Dockerfile-runner
@@ -10,7 +10,7 @@ RUN ["go", "mod", "download"]
 
 # Build the probe binary
 ARG PROBE_VERSION
-RUN ["env", "CGO_ENABLED=0", "GOOS=linux", "go", "build", "-ldflags=-w -s -extldflags '-static' -X 'github.com/grafana/nethax/pkg/kubernetes.ProbeImageVersion=${PROBE_VERSION}'", "-a", "-o", "runner", "./cmd/runner"]
+RUN env CGO_ENABLED=0 GOOS=linux go build -ldflags="-w -s -extldflags '-static' -X ${PROBE_VERSION}" -a -o /runner ./cmd/runner
 
 FROM scratch
 

--- a/Makefile
+++ b/Makefile
@@ -24,10 +24,10 @@ DIR_PROBE := "$(CUR_DIR)/cmd/probe"
 build: build-runner build-probe
 
 build-runner: deps-runner
-	@cd $(DIR_RUNNER) && go build -ldflags="-X 'github.com/grafana/nethax/pkg/kubernetes.ProbeImageVersion=$(PROBE_VERSION)'" -o "$(CUR_DIR)/bin"
+	go build -ldflags="-X 'github.com/grafana/nethax/pkg/kubernetes.ProbeImageVersion=$(PROBE_VERSION)'" -o "$(CUR_DIR)/bin" $(DIR_RUNNER)
 
 build-probe: deps-probe
-	@cd $(DIR_PROBE) && go build -ldflags="-X 'github.com/grafana/nethax/pkg/kubernetes.ProbeImageVersion=$(PROBE_VERSION)'" -o "$(CUR_DIR)/bin"
+	go build -ldflags="-X 'github.com/grafana/nethax/pkg/kubernetes.ProbeImageVersion=$(PROBE_VERSION)'" -o "$(CUR_DIR)/bin" $(DIR_PROBE)
 
 .PHONY: clean
 clean:
@@ -38,14 +38,8 @@ clean:
 # Default kind cluster name if not overridden
 KIND_CLUSTER_NAME ?= "nethax"
 
-deps: deps-runner deps-probe
-
-deps-runner:
-	@cd $(DIR_RUNNER) && go mod download
-
-deps-probe:
-	@cd $(DIR_PROBE) && go mod download
-
+deps:
+	go mod download
 
 .PHONY: docker docker-runner docker-probe
 docker: docker-runner docker-probe
@@ -72,10 +66,10 @@ test:
 kind-init-oteldemo:
 	@kind delete cluster --name $(KIND_CLUSTER_NAME) || true
 	@kind create cluster --name $(KIND_CLUSTER_NAME)
-	kubectl --context "kind-$(KIND_CLUSTER_NAME)" create ns otel-demo
-	kubectl --context "kind-$(KIND_CLUSTER_NAME)" apply -n otel-demo -f https://raw.githubusercontent.com/open-telemetry/opentelemetry-demo/main/kubernetes/opentelemetry-demo.yaml || true
-	kubectl --context "kind-$(KIND_CLUSTER_NAME)" create cm -n otel-demo grafana-dashboards
-	kubectl --context "kind-$(KIND_CLUSTER_NAME)" replace -n otel-demo -f https://raw.githubusercontent.com/open-telemetry/opentelemetry-demo/main/kubernetes/opentelemetry-demo.yaml
+	@kubectl --context "kind-$(KIND_CLUSTER_NAME)" create ns otel-demo
+	@kubectl --context "kind-$(KIND_CLUSTER_NAME)" apply -n otel-demo -f https://raw.githubusercontent.com/open-telemetry/opentelemetry-demo/main/kubernetes/opentelemetry-demo.yaml || true
+	@kubectl --context "kind-$(KIND_CLUSTER_NAME)" create cm -n otel-demo grafana-dashboards
+	@kubectl --context "kind-$(KIND_CLUSTER_NAME)" replace -n otel-demo -f https://raw.githubusercontent.com/open-telemetry/opentelemetry-demo/main/kubernetes/opentelemetry-demo.yaml
 
 .PHONY: run-example-test-plan
 # Default test plan path if not overridden

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-.PHONY: deps deps-runner deps-probe build build-runner build-probe test docker docker-runner docker-probe
+# Check we've got the necessary tools installed...
+EXECUTABLES = go docker kind kubectl
+K := $(foreach exec,$(EXECUTABLES),\
+        $(if $(shell which $(exec)), not found , $(error "No $(exec) in PATH")))
 
 # Set these to release new versions of the container
 RUNNER_SEMVER := "0.1.0"
@@ -7,11 +10,11 @@ PROBE_SEMVER := "0.1.0"
 CI := $(CI)
 
 ifdef CI
-	RUNNER_VERSION := ${RUNNER_SEMVER}
-	PROBE_VERSION := ${PROBE_SEMVER}
+	RUNNER_VERSION := $(RUNNER_SEMVER)
+	PROBE_VERSION := $(PROBE_SEMVER)
 else
-	RUNNER_VERSION := "${RUNNER_SEMVER}-$(shell date +%s)"
-	PROBE_VERSION := "${PROBE_SEMVER}-$(shell date +%s)"
+	RUNNER_VERSION := "$(RUNNER_SEMVER)-$(shell date +%s)"
+	PROBE_VERSION := "$(PROBE_SEMVER)-$(shell date +%s)"
 endif
 
 CUR_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
@@ -21,36 +24,72 @@ DIR_PROBE := "$(CUR_DIR)/cmd/probe"
 build: build-runner build-probe
 
 build-runner: deps-runner
-	@cd ${DIR_RUNNER} && go build -ldflags="-X 'github.com/grafana/nethax/pkg/kubernetes.ProbeImageVersion=${PROBE_VERSION}'" -o "$(CUR_DIR)/bin"
+	@cd $(DIR_RUNNER) && go build -ldflags="-X 'github.com/grafana/nethax/pkg/kubernetes.ProbeImageVersion=$(PROBE_VERSION)'" -o "$(CUR_DIR)/bin"
 
 build-probe: deps-probe
-	@cd ${DIR_PROBE} && go build -ldflags="-X 'github.com/grafana/nethax/pkg/kubernetes.ProbeImageVersion=${PROBE_VERSION}'" -o "$(CUR_DIR)/bin"
+	@cd $(DIR_PROBE) && go build -ldflags="-X 'github.com/grafana/nethax/pkg/kubernetes.ProbeImageVersion=$(PROBE_VERSION)'" -o "$(CUR_DIR)/bin"
 
+.PHONY: clean
 clean:
 	@rm -f "$(CUR_DIR)/bin/"*
+
+.PHONY: deps deps-runner deps-probe
+
+# Default kind cluster name if not overridden
+KIND_CLUSTER_NAME ?= "nethax"
 
 deps: deps-runner deps-probe
 
 deps-runner:
-	@cd ${DIR_RUNNER} && go mod download
+	@cd $(DIR_RUNNER) && go mod download
 
 deps-probe:
-	@cd ${DIR_PROBE} && go mod download
+	@cd $(DIR_PROBE) && go mod download
 
 
+.PHONY: docker docker-runner docker-probe
 docker: docker-runner docker-probe
 
 docker-runner:
-	@docker build -f Dockerfile-runner --build-arg PROBE_VERSION=${PROBE_VERSION} -t nethax-runner:${RUNNER_VERSION} .
+	@docker build -f Dockerfile-runner --build-arg PROBE_VERSION="'github.com/grafana/nethax/pkg/kubernetes.ProbeImageVersion=$(PROBE_VERSION)'" -t nethax-runner:$(RUNNER_VERSION) .
 ifndef CI
-	@kind load docker-image nethax-runner:${RUNNER_VERSION} || true
+	@kind load docker-image --name $(KIND_CLUSTER_NAME) nethax-runner:$(RUNNER_VERSION) || true
 endif
 
 docker-probe:
-	@docker build -f Dockerfile-probe --build-arg PROBE_VERSION=${PROBE_VERSION} -t nethax-probe:${PROBE_VERSION} .
+	@docker build -f Dockerfile-probe --build-arg PROBE_VERSION="'github.com/grafana/nethax/pkg/kubernetes.ProbeImageVersion=$(PROBE_VERSION)'" -t nethax-probe:$(PROBE_VERSION) .
 ifndef CI
-	@kind load docker-image nethax-probe:${PROBE_VERSION} || true
+	@kind load docker-image --name $(KIND_CLUSTER_NAME) nethax-probe:$(PROBE_VERSION) || true
 endif
 
+.PHONY: test
 test:
 	@go test ./...
+
+.PHONY: kind-init-oteldemo
+
+# Re-initializes a kind cluster with the OTel demo
+kind-init-oteldemo:
+	@kind delete cluster --name $(KIND_CLUSTER_NAME) || true
+	@kind create cluster --name $(KIND_CLUSTER_NAME)
+	kubectl --context "kind-$(KIND_CLUSTER_NAME)" create ns otel-demo
+	kubectl --context "kind-$(KIND_CLUSTER_NAME)" apply -n otel-demo -f https://raw.githubusercontent.com/open-telemetry/opentelemetry-demo/main/kubernetes/opentelemetry-demo.yaml || true
+	kubectl --context "kind-$(KIND_CLUSTER_NAME)" create cm -n otel-demo grafana-dashboards
+	kubectl --context "kind-$(KIND_CLUSTER_NAME)" replace -n otel-demo -f https://raw.githubusercontent.com/open-telemetry/opentelemetry-demo/main/kubernetes/opentelemetry-demo.yaml
+
+.PHONY: run-example-test-plan
+# Default test plan path if not overridden
+TEST_PLAN ?= "$(CUR_DIR)example/OtelDemoTestPlan.yaml"
+# Run the example test plan against KIND_CLUSTER_NAME
+run-example-test-plan: docker
+	@echo "Running test plan: $(TEST_PLAN)"
+	@TMP_KUBECONFIG=$$(mktemp) && \
+	kind get kubeconfig --name $(KIND_CLUSTER_NAME) > $$TMP_KUBECONFIG && \
+	docker run --rm \
+		--network host \
+		--mount "type=bind,source=$$TMP_KUBECONFIG,target=/.kube/config,readonly" \
+		--mount "type=bind,source=$(TEST_PLAN),target=/test-plan.yaml,readonly" \
+		-e "KUBECONFIG=/.kube/config" \
+		--user $(id -u):$(id -g) \
+		nethax-runner:$(RUNNER_VERSION) "execute-test" "-f" "/test-plan.yaml"; \
+	rm -rf $$TMP_KUBECONFIG


### PR DESCRIPTION
Adds:
- `CONTRIBUTING.md` file with getting started instructions
- Make target to initialize a test cluster with kind
- Make target to run the example test plan against test cluster
- Various fixes to Makefile syntax
- Use same syntax in both Dockerfiles

You can test this locally by running make kind-init-oteldemo run-example-test-plan.
