### PR TITLE
Refactor probes to reduce duplication

### DIFF
--- a/cmd/probe/http_probe.go
+++ b/cmd/probe/http_probe.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"time"
@@ -22,7 +23,7 @@ func NewHTTPProbe(url string, timeout time.Duration, status int) *HTTPProbe {
 	}
 }
 
-func (p *HTTPProbe) Run() error {
+func (p *HTTPProbe) Run(_ context.Context) error {
 	c := &http.Client{
 		Timeout: timeout,
 	}

--- a/cmd/probe/http_probe.go
+++ b/cmd/probe/http_probe.go
@@ -23,12 +23,16 @@ func NewHTTPProbe(url string, timeout time.Duration, status int) *HTTPProbe {
 	}
 }
 
-func (p *HTTPProbe) Run(_ context.Context) error {
-	c := &http.Client{
-		Timeout: timeout,
+func (p *HTTPProbe) Run(ctx context.Context) error {
+	ctx, cancel := context.WithTimeout(ctx, p.timeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, p.url, nil)
+	if err != nil {
+		return err
 	}
 
-	res, err := c.Get(p.url)
+	res, err := http.DefaultClient.Do(req)
 	if err != nil {
 		if p.status == 0 { // expecting failure
 			return nil

--- a/cmd/probe/http_probe.go
+++ b/cmd/probe/http_probe.go
@@ -24,7 +24,7 @@ func NewHTTPProbe(url string, timeout time.Duration, expectedStatus int) *HTTPPr
 	}
 }
 
-func (p *HTTPProbe) Run() {
+func (p *HTTPProbe) Run() error {
 	c := &http.Client{
 		Timeout: timeout,
 	}
@@ -32,14 +32,11 @@ func (p *HTTPProbe) Run() {
 	res, err := c.Get(p.url)
 	if err != nil {
 		p.err = err
-		return
+	} else {
+		defer res.Body.Close() //nolint:errcheck
+		p.resStatus = res.StatusCode
 	}
-	defer res.Body.Close() //nolint:errcheck
 
-	p.resStatus = res.StatusCode
-}
-
-func (p *HTTPProbe) Assert() error {
 	if p.expStatus == 0 && p.err == nil {
 		return errConnectionSucceeded
 	} else if p.expStatus != 0 && p.err != nil {

--- a/cmd/probe/http_probe.go
+++ b/cmd/probe/http_probe.go
@@ -4,29 +4,23 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"time"
 )
 
 var _ Probe = &HTTPProbe{}
 
 type HTTPProbe struct {
-	url     string
-	timeout time.Duration
-	status  int
+	url    string
+	status int
 }
 
-func NewHTTPProbe(url string, timeout time.Duration, status int) *HTTPProbe {
+func NewHTTPProbe(url string, status int) *HTTPProbe {
 	return &HTTPProbe{
-		url:     url,
-		timeout: timeout,
-		status:  status,
+		url:    url,
+		status: status,
 	}
 }
 
 func (p *HTTPProbe) Run(ctx context.Context) error {
-	ctx, cancel := context.WithTimeout(ctx, p.timeout)
-	defer cancel()
-
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, p.url, nil)
 	if err != nil {
 		return err

--- a/cmd/probe/http_probe.go
+++ b/cmd/probe/http_probe.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+)
+
+var _ Probe = &HTTPProbe{}
+
+type HTTPProbe struct {
+	url       string
+	timeout   time.Duration
+	resStatus int
+	expStatus int
+	err       error
+}
+
+func NewHTTPProbe(url string, timeout time.Duration, expectedStatus int) *HTTPProbe {
+	return &HTTPProbe{
+		url:       url,
+		timeout:   timeout,
+		expStatus: expectedStatus,
+	}
+}
+
+func (p *HTTPProbe) Run() {
+	c := &http.Client{
+		Timeout: timeout,
+	}
+
+	res, err := c.Get(p.url)
+	if err != nil {
+		p.err = err
+		return
+	}
+	defer res.Body.Close() //nolint:errcheck
+
+	p.resStatus = res.StatusCode
+}
+
+func (p *HTTPProbe) Assert() error {
+	if p.expStatus == 0 && p.err == nil {
+		return errConnectionSucceeded
+	} else if p.expStatus != 0 && p.err != nil {
+		return fmt.Errorf("%w: %w", errConnectionFailed, p.err)
+	} else if p.expStatus != p.resStatus {
+		return fmt.Errorf("%w: expecting response code %d, got %d", errAssertionFailed, p.expStatus, p.resStatus)
+	}
+
+	return nil
+}

--- a/cmd/probe/http_probe.go
+++ b/cmd/probe/http_probe.go
@@ -11,12 +11,18 @@ var _ Probe = &HTTPProbe{}
 type HTTPProbe struct {
 	url    string
 	status int
+	client *http.Client
 }
 
 func NewHTTPProbe(url string, status int) *HTTPProbe {
+	return NewHTTPProbeWithClient(url, status, http.DefaultClient)
+}
+
+func NewHTTPProbeWithClient(url string, status int, client *http.Client) *HTTPProbe {
 	return &HTTPProbe{
 		url:    url,
 		status: status,
+		client: client,
 	}
 }
 
@@ -26,7 +32,7 @@ func (p *HTTPProbe) Run(ctx context.Context) error {
 		return err
 	}
 
-	res, err := http.DefaultClient.Do(req)
+	res, err := p.client.Do(req)
 	if err != nil {
 		if p.status == 0 { // expecting failure
 			return nil

--- a/cmd/probe/http_probe_test.go
+++ b/cmd/probe/http_probe_test.go
@@ -17,9 +17,8 @@ func TestHTTPProbe(t *testing.T) {
 		}))
 
 		p := NewHTTPProbe(ts.URL, time.Second, status)
-		p.Run()
 
-		if err := p.Assert(); err != nil {
+		if err := p.Run(); err != nil {
 			t.Fatal(err)
 		}
 	})
@@ -29,9 +28,8 @@ func TestHTTPProbe(t *testing.T) {
 		}))
 
 		p := NewHTTPProbe(ts.URL, time.Second, 0)
-		p.Run()
 
-		if err := p.Assert(); err != nil {
+		if err := p.Run(); err != nil {
 			t.Fatal(err)
 		}
 	})
@@ -42,9 +40,8 @@ func TestHTTPProbe(t *testing.T) {
 		}))
 
 		p := NewHTTPProbe(ts.URL, time.Second, 0)
-		p.Run()
 
-		if err := p.Assert(); !errors.Is(err, errConnectionSucceeded) {
+		if err := p.Run(); !errors.Is(err, errConnectionSucceeded) {
 			t.Fatalf("expecting error %v, got %v", errConnectionSucceeded, err)
 		}
 	})
@@ -55,9 +52,8 @@ func TestHTTPProbe(t *testing.T) {
 		}))
 
 		p := NewHTTPProbe(ts.URL, time.Second, http.StatusOK)
-		p.Run()
 
-		if err := p.Assert(); !errors.Is(err, errAssertionFailed) {
+		if err := p.Run(); !errors.Is(err, errAssertionFailed) {
 			t.Fatalf("expecting error %v, got %v", errAssertionFailed, err)
 		}
 	})
@@ -68,9 +64,8 @@ func TestHTTPProbe(t *testing.T) {
 		}))
 
 		p := NewHTTPProbe(ts.URL, time.Second, http.StatusOK)
-		p.Run()
 
-		if err := p.Assert(); !errors.Is(err, errConnectionFailed) {
+		if err := p.Run(); !errors.Is(err, errConnectionFailed) {
 			t.Fatalf("expecting error %v, got %v", errConnectionFailed, err)
 		}
 	})

--- a/cmd/probe/http_probe_test.go
+++ b/cmd/probe/http_probe_test.go
@@ -18,7 +18,7 @@ func TestHTTPProbe(t *testing.T) {
 
 		p := NewHTTPProbe(ts.URL, time.Second, status)
 
-		if err := p.Run(); err != nil {
+		if err := p.Run(t.Context()); err != nil {
 			t.Fatal(err)
 		}
 	})
@@ -29,7 +29,7 @@ func TestHTTPProbe(t *testing.T) {
 
 		p := NewHTTPProbe(ts.URL, time.Second, 0)
 
-		if err := p.Run(); err != nil {
+		if err := p.Run(t.Context()); err != nil {
 			t.Fatal(err)
 		}
 	})
@@ -41,7 +41,7 @@ func TestHTTPProbe(t *testing.T) {
 
 		p := NewHTTPProbe(ts.URL, time.Second, 0)
 
-		if err := p.Run(); !errors.Is(err, errConnectionSucceeded) {
+		if err := p.Run(t.Context()); !errors.Is(err, errConnectionSucceeded) {
 			t.Fatalf("expecting error %v, got %v", errConnectionSucceeded, err)
 		}
 	})
@@ -53,7 +53,7 @@ func TestHTTPProbe(t *testing.T) {
 
 		p := NewHTTPProbe(ts.URL, time.Second, http.StatusOK)
 
-		if err := p.Run(); !errors.Is(err, errAssertionFailed) {
+		if err := p.Run(t.Context()); !errors.Is(err, errAssertionFailed) {
 			t.Fatalf("expecting error %v, got %v", errAssertionFailed, err)
 		}
 	})
@@ -65,7 +65,7 @@ func TestHTTPProbe(t *testing.T) {
 
 		p := NewHTTPProbe(ts.URL, time.Second, http.StatusOK)
 
-		if err := p.Run(); !errors.Is(err, errConnectionFailed) {
+		if err := p.Run(t.Context()); !errors.Is(err, errConnectionFailed) {
 			t.Fatalf("expecting error %v, got %v", errConnectionFailed, err)
 		}
 	})

--- a/cmd/probe/http_probe_test.go
+++ b/cmd/probe/http_probe_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"time"
 )
 
 func TestHTTPProbe(t *testing.T) {
@@ -17,7 +16,7 @@ func TestHTTPProbe(t *testing.T) {
 			w.WriteHeader(status)
 		}))
 
-		p := NewHTTPProbe(ts.URL, time.Second, status)
+		p := NewHTTPProbe(ts.URL, status)
 
 		if err := p.Run(t.Context()); err != nil {
 			t.Fatal(err)
@@ -28,7 +27,7 @@ func TestHTTPProbe(t *testing.T) {
 		ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		}))
 
-		p := NewHTTPProbe(ts.URL, time.Second, 0)
+		p := NewHTTPProbe(ts.URL, 0)
 
 		if err := p.Run(t.Context()); err != nil {
 			t.Fatal(err)
@@ -40,7 +39,7 @@ func TestHTTPProbe(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 		}))
 
-		p := NewHTTPProbe(ts.URL, time.Second, 0)
+		p := NewHTTPProbe(ts.URL, 0)
 
 		if err := p.Run(t.Context()); !errors.Is(err, errConnectionSucceeded) {
 			t.Fatalf("expecting error %v, got %v", errConnectionSucceeded, err)
@@ -52,7 +51,7 @@ func TestHTTPProbe(t *testing.T) {
 			w.WriteHeader(http.StatusInternalServerError)
 		}))
 
-		p := NewHTTPProbe(ts.URL, time.Second, http.StatusOK)
+		p := NewHTTPProbe(ts.URL, http.StatusOK)
 
 		if err := p.Run(t.Context()); !errors.Is(err, errAssertionFailed) {
 			t.Fatalf("expecting error %v, got %v", errAssertionFailed, err)
@@ -64,7 +63,7 @@ func TestHTTPProbe(t *testing.T) {
 			w.WriteHeader(http.StatusInternalServerError)
 		}))
 
-		p := NewHTTPProbe(ts.URL, time.Second, http.StatusOK)
+		p := NewHTTPProbe(ts.URL, http.StatusOK)
 
 		if err := p.Run(t.Context()); !errors.Is(err, errConnectionFailed) {
 			t.Fatalf("expecting error %v, got %v", errConnectionFailed, err)
@@ -76,7 +75,7 @@ func TestHTTPProbe(t *testing.T) {
 			w.WriteHeader(http.StatusOK)
 		}))
 
-		p := NewHTTPProbe(ts.URL, time.Second, http.StatusOK)
+		p := NewHTTPProbe(ts.URL, http.StatusOK)
 
 		ctx, cancel := context.WithCancel(t.Context())
 		cancel()

--- a/cmd/probe/http_probe_test.go
+++ b/cmd/probe/http_probe_test.go
@@ -1,0 +1,77 @@
+package main
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func TestHTTPProbe(t *testing.T) {
+	t.Run("expecting status code", func(t *testing.T) {
+		status := http.StatusOK
+
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(status)
+		}))
+
+		p := NewHTTPProbe(ts.URL, time.Second, status)
+		p.Run()
+
+		if err := p.Assert(); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("expecting connection failure", func(t *testing.T) {
+		ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		}))
+
+		p := NewHTTPProbe(ts.URL, time.Second, 0)
+		p.Run()
+
+		if err := p.Assert(); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("connection succeeded", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		p := NewHTTPProbe(ts.URL, time.Second, 0)
+		p.Run()
+
+		if err := p.Assert(); !errors.Is(err, errConnectionSucceeded) {
+			t.Fatalf("expecting error %v, got %v", errConnectionSucceeded, err)
+		}
+	})
+
+	t.Run("unexpected response", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+
+		p := NewHTTPProbe(ts.URL, time.Second, http.StatusOK)
+		p.Run()
+
+		if err := p.Assert(); !errors.Is(err, errAssertionFailed) {
+			t.Fatalf("expecting error %v, got %v", errAssertionFailed, err)
+		}
+	})
+
+	t.Run("connection failure", func(t *testing.T) {
+		ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+
+		p := NewHTTPProbe(ts.URL, time.Second, http.StatusOK)
+		p.Run()
+
+		if err := p.Assert(); !errors.Is(err, errConnectionFailed) {
+			t.Fatalf("expecting error %v, got %v", errConnectionFailed, err)
+		}
+	})
+}

--- a/cmd/probe/http_probe_test.go
+++ b/cmd/probe/http_probe_test.go
@@ -84,4 +84,18 @@ func TestHTTPProbe(t *testing.T) {
 			t.Fatalf("expecting error %v, got %v", context.Canceled, err)
 		}
 	})
+
+	t.Run("custom client", func(t *testing.T) {
+		status := http.StatusOK
+
+		ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(status)
+		}))
+
+		p := NewHTTPProbeWithClient(ts.URL, status, ts.Client())
+
+		if err := p.Run(t.Context()); err != nil {
+			t.Fatal(err)
+		}
+	})
 }

--- a/cmd/probe/main.go
+++ b/cmd/probe/main.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"net"
-	"net/http"
 	"time"
 
 	"github.com/grafana/nethax/pkg/common"
@@ -50,50 +48,4 @@ func main() {
 
 	fmt.Println("Probe succeeded")
 	common.ExitSuccess()
-}
-
-func testTCPConnection() {
-	conn, err := net.DialTimeout("tcp", url, timeout)
-	if err != nil {
-		if expectFail {
-			fmt.Println("TCP connection failed as expected:", err)
-			common.ExitSuccess()
-		}
-		fmt.Println("TCP connection failed unexpectedly:", err)
-		common.ExitFailure()
-	}
-	defer conn.Close()
-
-	if expectFail {
-		fmt.Println("TCP connection succeeded unexpectedly")
-		common.ExitFailure()
-	}
-
-	fmt.Println("TCP connection succeeded")
-	common.ExitSuccess()
-}
-
-func testHTTPConnection() {
-	client := &http.Client{
-		Timeout: timeout,
-	}
-
-	resp, err := client.Get(url)
-	if err != nil {
-		if expectedStatus == 0 {
-			fmt.Println("Connection failed as expected:", err)
-			common.ExitSuccess()
-		}
-		fmt.Println("Connection failed unexpectedly:", err)
-		common.ExitFailure()
-	}
-	defer resp.Body.Close()
-
-	if resp.StatusCode == expectedStatus {
-		fmt.Printf("Connection succeeded with expected status code %d\n", expectedStatus)
-		common.ExitSuccess()
-	}
-
-	fmt.Printf("Connection succeeded but got status code %d, expected %d\n", resp.StatusCode, expectedStatus)
-	common.ExitFailure()
 }

--- a/cmd/probe/main.go
+++ b/cmd/probe/main.go
@@ -43,7 +43,7 @@ func main() {
 
 	if err := probe.Run(ctx); err != nil {
 		fmt.Println("Probe failed unexpectedly:", err)
-		common.ExitSuccess()
+		common.ExitFailure()
 	}
 
 	fmt.Println("Probe succeeded")

--- a/cmd/probe/main.go
+++ b/cmd/probe/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"net"
@@ -31,11 +32,24 @@ func main() {
 		common.ExitFailure()
 	}
 
+	var probe Probe
+
 	if testType == "tcp" {
-		testTCPConnection()
+		probe = NewTCPProbe(url, expectFail)
 	} else {
-		testHTTPConnection()
+		probe = NewHTTPProbe(url, expectedStatus)
 	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	if err := probe.Run(ctx); err != nil {
+		fmt.Println("Probe failed unexpectedly:", err)
+		common.ExitSuccess()
+	}
+
+	fmt.Println("Probe succeeded")
+	common.ExitSuccess()
 }
 
 func testTCPConnection() {

--- a/cmd/probe/probe.go
+++ b/cmd/probe/probe.go
@@ -5,8 +5,7 @@ import (
 )
 
 type Probe interface {
-	Run()
-	Assert() error
+	Run() error
 }
 
 var (

--- a/cmd/probe/probe.go
+++ b/cmd/probe/probe.go
@@ -1,0 +1,16 @@
+package main
+
+import (
+	"errors"
+)
+
+type Probe interface {
+	Run()
+	Assert() error
+}
+
+var (
+	errConnectionSucceeded = errors.New("connection succeeded when expecting a failure")
+	errConnectionFailed    = errors.New("connection failed")
+	errAssertionFailed     = errors.New("assertion failed")
+)

--- a/cmd/probe/probe.go
+++ b/cmd/probe/probe.go
@@ -1,11 +1,12 @@
 package main
 
 import (
+	"context"
 	"errors"
 )
 
 type Probe interface {
-	Run() error
+	Run(context.Context) error
 }
 
 var (

--- a/cmd/probe/tcp_probe.go
+++ b/cmd/probe/tcp_probe.go
@@ -1,0 +1,41 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net"
+)
+
+var _ Probe = TCPProbe{}
+
+type TCPProbe struct {
+	addr string
+	fail bool
+}
+
+func NewTCPProbe(addr string, fail bool) TCPProbe {
+	return TCPProbe{
+		addr: addr,
+		fail: fail,
+	}
+}
+
+func (p TCPProbe) Run(ctx context.Context) error {
+	var d net.Dialer
+
+	cn, err := d.DialContext(ctx, "tcp", p.addr)
+	if err != nil {
+		if p.fail {
+			return nil
+		}
+
+		return fmt.Errorf("%w: %w", errConnectionFailed, err)
+	}
+	defer cn.Close() //nolint:errcheck
+
+	if p.fail {
+		return fmt.Errorf("%w: %w", errAssertionFailed, errConnectionSucceeded)
+	}
+
+	return nil
+}

--- a/cmd/probe/tcp_probe_test.go
+++ b/cmd/probe/tcp_probe_test.go
@@ -40,7 +40,7 @@ func TestTCPProbe(t *testing.T) {
 			t.Fatalf("unexpected error creating listener: %v", err)
 		}
 
-		p := NewTCPProbe(l.Addr().String(), true)
+		p := NewTCPProbe(l.Addr().String(), false)
 
 		l.Close()
 
@@ -55,7 +55,7 @@ func TestTCPProbe(t *testing.T) {
 			t.Fatalf("unexpected error creating listener: %v", err)
 		}
 
-		p := NewTCPProbe(l.Addr().String(), true)
+		p := NewTCPProbe(l.Addr().String(), false)
 
 		ctx, cancel := context.WithCancel(t.Context())
 		cancel()

--- a/cmd/probe/tcp_probe_test.go
+++ b/cmd/probe/tcp_probe_test.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+)
+
+func TestTCPProbe(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		l, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("unexpected error creating listener: %v", err)
+		}
+
+		p := NewTCPProbe(l.Addr().String(), false)
+
+		if err := p.Run(t.Context()); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("conn should fail", func(t *testing.T) {
+		l, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("unexpected error creating listener: %v", err)
+		}
+
+		p := NewTCPProbe(l.Addr().String(), true)
+
+		if err := p.Run(t.Context()); !errors.Is(err, errConnectionSucceeded) {
+			t.Fatalf("expecting error %v, got %v", errConnectionSucceeded, err)
+		}
+	})
+
+	t.Run("conn should not fail", func(t *testing.T) {
+		l, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("unexpected error creating listener: %v", err)
+		}
+
+		p := NewTCPProbe(l.Addr().String(), true)
+
+		l.Close()
+
+		if err := p.Run(t.Context()); !errors.Is(err, errConnectionFailed) {
+			t.Fatalf("expecting error %v, got %v", errConnectionFailed, err)
+		}
+	})
+
+	t.Run("context aware", func(t *testing.T) {
+		l, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			t.Fatalf("unexpected error creating listener: %v", err)
+		}
+
+		p := NewTCPProbe(l.Addr().String(), true)
+
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+
+		if err := p.Run(ctx); !errors.Is(err, context.Canceled) {
+			t.Fatalf("expecting error %v, got %v", context.Canceled, err)
+		}
+	})
+}


### PR DESCRIPTION
Refactor `cmd/probe` probes to reduce duplication of logic and also to make them more testeables.

The main different in `main.go` is that the amount of information display is reduced, however we gain better maintainability.