### PR TITLE
chore: Push to Docker Hub

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,46 @@
+name: Build and Push Image
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - v*
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  REGISTRY_IMAGE: grafana/nethax
+  TAGS_CONFIG: |
+    type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+    type=sha,prefix={{ branch }}-,format=short,enable=${{ github.ref == 'refs/heads/main' }}
+    type=semver,pattern={{ version }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        with:
+          persist-credentials: false
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Build and push - Probe
+        uses: grafana/shared-workflows/actions/build-push-to-dockerhub@402975d84dd3fac9ba690f994f412d0ee2f51cf4 # build-push-to-dockerhub-v0.1.1
+        with:
+          repository: ${{ env.REGISTRY_IMAGE }}
+          context: .
+          push: true
+          file: Dockerfile-probe
+          platforms: linux/amd64
+          tags: ${{ env.TAGS_CONFIG }}
+      - name: Build and push - Runner
+        uses: grafana/shared-workflows/actions/build-push-to-dockerhub@402975d84dd3fac9ba690f994f412d0ee2f51cf4 # build-push-to-dockerhub-v0.1.1
+        with:
+          repository: ${{ env.REGISTRY_IMAGE }}
+          context: .
+          push: true
+          file: Dockerfile-runner
+          platforms: linux/amd64
+          tags: ${{ env.TAGS_CONFIG }}

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ K := $(foreach exec,$(EXECUTABLES),\
 endif
 
 # Set these to release new versions of the container
-RUNNER_SEMVER := "0.1.0"
-PROBE_SEMVER := "0.1.0"
+RUNNER_SEMVER := "0.0.1"
+PROBE_SEMVER := "0.0.1"
 
 ifdef CI
 	RUNNER_VERSION := $(RUNNER_SEMVER)


### PR DESCRIPTION
Now that we're using this for more than simple test cases locally, this needs to live somewhere more permanent.

This change pushes tags and main branch builds to Docker Hub. This can form the start of our releasing process. I will cut a v0.0.1 tag after this is merged.
