### PR TITLE
Pass PROBE_VERSION as version instead of full -X flag

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,7 +19,7 @@ env:
     type=semver,pattern={{ version }}
 
 jobs:
-  build:
+  docker:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/Dockerfile-probe
+++ b/Dockerfile-probe
@@ -10,7 +10,7 @@ RUN ["go", "mod", "download"]
 
 # Build the probe binary
 ARG PROBE_VERSION
-RUN env CGO_ENABLED=0 GOOS=linux go build -ldflags="-w -s -extldflags '-static' -X ${PROBE_VERSION}" -a -o /probe ./cmd/probe
+RUN env CGO_ENABLED=0 GOOS=linux go build -ldflags="-w -s -extldflags '-static' -X 'github.com/grafana/nethax/pkg/kubernetes.ProbeImageVersion=${PROBE_VERSION}'" -a -o /probe ./cmd/probe
 
 FROM scratch
 

--- a/Dockerfile-runner
+++ b/Dockerfile-runner
@@ -10,7 +10,7 @@ RUN ["go", "mod", "download"]
 
 # Build the probe binary
 ARG PROBE_VERSION
-RUN env CGO_ENABLED=0 GOOS=linux go build -ldflags="-w -s -extldflags '-static' -X ${PROBE_VERSION}" -a -o /runner ./cmd/runner
+RUN env CGO_ENABLED=0 GOOS=linux go build -ldflags="-w -s -extldflags '-static' -X 'github.com/grafana/nethax/pkg/kubernetes.ProbeImageVersion=${PROBE_VERSION}'" -a -o /runner ./cmd/runner
 
 FROM scratch
 

--- a/Makefile
+++ b/Makefile
@@ -47,13 +47,13 @@ deps:
 docker: docker-runner docker-probe
 
 docker-runner:
-	@docker build -f Dockerfile-runner --build-arg PROBE_VERSION="'github.com/grafana/nethax/pkg/kubernetes.ProbeImageVersion=$(PROBE_VERSION)'" -t nethax-runner:$(RUNNER_VERSION) .
+	@docker build -f Dockerfile-runner --build-arg PROBE_VERSION=$(PROBE_VERSION) -t nethax-runner:$(RUNNER_VERSION) .
 ifndef CI
 	@kind load docker-image --name $(KIND_CLUSTER_NAME) nethax-runner:$(RUNNER_VERSION) || true
 endif
 
 docker-probe:
-	@docker build -f Dockerfile-probe --build-arg PROBE_VERSION="'github.com/grafana/nethax/pkg/kubernetes.ProbeImageVersion=$(PROBE_VERSION)'" -t nethax-probe:$(PROBE_VERSION) .
+	@docker build -f Dockerfile-probe --build-arg PROBE_VERSION=$(PROBE_VERSION) -t nethax-probe:$(PROBE_VERSION) .
 ifndef CI
 	@kind load docker-image --name $(KIND_CLUSTER_NAME) nethax-probe:$(PROBE_VERSION) || true
 endif


### PR DESCRIPTION
We were getting a build error with the previous version, which was pointing at the `-X` flag of `go build -ldflags` not being properly formatted. By only passing the version instead of the whole import path for overriding the value at compile time we hope it will fix this error.

    #10 9.570 /usr/local/go/pkg/tool/linux_amd64/link: -X flag requires argument of the form importpath.name=value