### PR TITLE
Refactor `pkg/kubernetes`

### DIFF
--- a/cmd/runner/executetest.go
+++ b/cmd/runner/executetest.go
@@ -14,7 +14,6 @@ import (
 	"github.com/grafana/nethax/pkg/kubernetes"
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // ExecuteTest returns the execute-test command
@@ -171,19 +170,12 @@ func isPodReady(pod *corev1.Pod) bool {
 }
 
 func findPods(ctx context.Context, k *kubernetes.Kubernetes, mode, namespace, selector string) ([]corev1.Pod, error) {
-	// Find pods matching the selector
-	pods, err := k.Client.CoreV1().Pods(namespace).List(ctx, v1.ListOptions{
-		LabelSelector: selector,
-	})
+	pods, err := k.GetPods(ctx, namespace, selector)
 	if err != nil {
 		return nil, fmt.Errorf("failed to find pods: %w", err)
 	}
 
-	if len(pods.Items) == 0 {
-		return nil, fmt.Errorf("no pods found matching selector %s", selector)
-	}
-
-	return selectPods(mode, pods.Items)
+	return selectPods(mode, pods)
 }
 
 var (

--- a/cmd/runner/executetest.go
+++ b/cmd/runner/executetest.go
@@ -43,7 +43,7 @@ func ExecuteTest() *cobra.Command {
 				common.ExitConfigError()
 			}
 
-			k, err := kubernetes.GetKubernetes("")
+			k, err := kubernetes.New("")
 			if err != nil {
 				cmd.Printf("Error creating Kubernetes client: %v\n", err)
 				common.ExitConfigError()

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -25,7 +25,9 @@ var (
 	ProbeImageVersion = "latest"
 )
 
-func GetKubernetes(context string) (*Kubernetes, error) {
+// New returns a new Kubernetes object, connected to the given
+// context, or to the in-cluster API if blank.
+func New(context string) (*Kubernetes, error) {
 	// attempt to use config from pod service account
 	config, err := rest.InClusterConfig()
 	if err != nil {

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -40,7 +40,6 @@ func New(context string) (*Kubernetes, error) {
 
 	return &Kubernetes{
 		client: client,
-		config: config,
 	}, nil
 }
 
@@ -63,7 +62,6 @@ func getClusterConfig(kontext string) (*rest.Config, error) {
 }
 
 type Kubernetes struct {
-	config *rest.Config
 	client kubernetes.Interface
 }
 

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -52,20 +52,20 @@ func GetKubernetes(context string) (*Kubernetes, error) {
 	}
 
 	return &Kubernetes{
-		Client: client,
-		Config: config,
+		client: client,
+		config: config,
 	}, nil
 }
 
 type Kubernetes struct {
-	Config *rest.Config
-	Client kubernetes.Interface
+	config *rest.Config
+	client kubernetes.Interface
 }
 
 var errNoPodsFound = errors.New("no pods found")
 
 func (k *Kubernetes) GetPods(ctx context.Context, namespace, selector string) ([]corev1.Pod, error) {
-	pods, err := k.Client.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+	pods, err := k.client.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
 		LabelSelector: selector,
 	})
 	if err != nil {
@@ -118,7 +118,7 @@ func (k *Kubernetes) LaunchEphemeralContainer(ctx context.Context, pod *corev1.P
 		return nil, ephemeralName, fmt.Errorf("error creating patch to add debug container: %v", err)
 	}
 
-	pods := k.Client.CoreV1().Pods(pod.Namespace)
+	pods := k.client.CoreV1().Pods(pod.Namespace)
 	result, err := pods.Patch(ctx, pod.Name, types.StrategicMergePatchType, patch, metav1.PatchOptions{}, "ephemeralcontainers")
 	if err != nil {
 		return nil, ephemeralName, fmt.Errorf("error patching pod with debug container: %v", err)
@@ -128,7 +128,7 @@ func (k *Kubernetes) LaunchEphemeralContainer(ctx context.Context, pod *corev1.P
 }
 
 func (k *Kubernetes) getEphemeralContainerExitStatus(ctx context.Context, pod *corev1.Pod, ephemeralContainerName string) (int32, error) {
-	pod, err := k.Client.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
+	pod, err := k.client.CoreV1().Pods(pod.Namespace).Get(ctx, pod.Name, metav1.GetOptions{})
 	if err != nil {
 		return -1, err
 	}

--- a/pkg/kubernetes/kubernetes_test.go
+++ b/pkg/kubernetes/kubernetes_test.go
@@ -12,13 +12,13 @@ import (
 
 func setup() *Kubernetes {
 	return &Kubernetes{
-		Client: testClient.NewSimpleClientset(),
+		client: testClient.NewSimpleClientset(),
 	}
 }
 
 func TestGetPods(t *testing.T) {
 	k := &Kubernetes{
-		Client: testClient.NewSimpleClientset(
+		client: testClient.NewSimpleClientset(
 			&corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: "nethax",
@@ -101,7 +101,7 @@ func TestLaunchEphemeralContainer(t *testing.T) {
 	name := "grafanyaa"
 	namespace := &corev1.Namespace{
 		ObjectMeta: metav1.ObjectMeta{Name: name}}
-	k.Client.CoreV1().Namespaces().Create(t.Context(), namespace, metav1.CreateOptions{})
+	k.client.CoreV1().Namespaces().Create(t.Context(), namespace, metav1.CreateOptions{})
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: name,
@@ -113,7 +113,7 @@ func TestLaunchEphemeralContainer(t *testing.T) {
 			},
 		},
 	}
-	k.Client.CoreV1().Pods(name).Create(t.Context(), pod, metav1.CreateOptions{})
+	k.client.CoreV1().Pods(name).Create(t.Context(), pod, metav1.CreateOptions{})
 
 	// execute
 	actual, _, _ := k.LaunchEphemeralContainer(t.Context(), pod, []string{"nyaa"}, []string{"rawr"})
@@ -124,6 +124,6 @@ func TestLaunchEphemeralContainer(t *testing.T) {
 	}
 
 	// clean up
-	k.Client.CoreV1().Pods(name).Delete(t.Context(), name, metav1.DeleteOptions{})
-	k.Client.CoreV1().Namespaces().Delete(t.Context(), name, metav1.DeleteOptions{})
+	k.client.CoreV1().Pods(name).Delete(t.Context(), name, metav1.DeleteOptions{})
+	k.client.CoreV1().Namespaces().Delete(t.Context(), name, metav1.DeleteOptions{})
 }


### PR DESCRIPTION
This PR refactos `pkg/kubernetes` to make it a bit more Goish™, and also tries add some missing unit tests. I think the full _files_ view should be enough, but in any case each commit is trying to be as small and scoped as possible so it might be easier to review that way.