### PR TITLE
feat: Make Probe Container Image Configurable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,15 +47,15 @@ deps:
 docker: docker-runner docker-probe
 
 docker-runner:
-	@docker build -f Dockerfile-runner --build-arg PROBE_VERSION=$(PROBE_VERSION) -t nethax-runner:$(RUNNER_VERSION) .
+	@docker build -f Dockerfile-runner --build-arg PROBE_VERSION=$(PROBE_VERSION) -t grafana/nethax-runner:$(RUNNER_VERSION) .
 ifndef CI
-	@kind load docker-image --name $(KIND_CLUSTER_NAME) nethax-runner:$(RUNNER_VERSION) || true
+	@kind load docker-image --name $(KIND_CLUSTER_NAME) grafana/nethax-runner:$(RUNNER_VERSION) || true
 endif
 
 docker-probe:
-	@docker build -f Dockerfile-probe --build-arg PROBE_VERSION=$(PROBE_VERSION) -t nethax-probe:$(PROBE_VERSION) .
+	@docker build -f Dockerfile-probe --build-arg PROBE_VERSION=$(PROBE_VERSION) -t grafana/nethax-probe:$(PROBE_VERSION) .
 ifndef CI
-	@kind load docker-image --name $(KIND_CLUSTER_NAME) nethax-probe:$(PROBE_VERSION) || true
+	@kind load docker-image --name $(KIND_CLUSTER_NAME) grafana/nethax-probe:$(PROBE_VERSION) || true
 endif
 
 .PHONY: test
@@ -87,7 +87,7 @@ run-example-test-plan: docker
 		--mount "type=bind,source=$(TEST_PLAN),target=/test-plan.yaml,readonly" \
 		-e "KUBECONFIG=/.kube/config" \
 		--user $(id -u):$(id -g) \
-		nethax-runner:$(RUNNER_VERSION) "execute-test" "-f" "/test-plan.yaml"; \
+		grafana/nethax-runner:$(RUNNER_VERSION) "execute-test" "-f" "/test-plan.yaml"; \
 	rm -rf $$TMP_KUBECONFIG
 
 .PHONY: checks

--- a/cmd/runner/executetest.go
+++ b/cmd/runner/executetest.go
@@ -17,10 +17,13 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+var (
+	testFile             string
+	netHaxProbeContainer string
+)
+
 // ExecuteTest returns the execute-test command
 func ExecuteTest() *cobra.Command {
-	var testFile string
-
 	cmd := &cobra.Command{
 		Use:   "execute-test -f example/OtelDemoTestPlan.yaml",
 		Short: "Execute network connectivity test plan",
@@ -57,6 +60,7 @@ func ExecuteTest() *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&testFile, "file", "f", "", "Path to the test configuration YAML file")
+	cmd.Flags().StringVarP(&netHaxProbeContainer, "probe-container", "p", "grafana/nethax-probe", "The name of the image used for the ephemeral probe container. Must be a valid Kubernetes container image name.")
 	cmd.MarkFlagRequired("file") //nolint:errcheck
 
 	return cmd
@@ -133,7 +137,7 @@ func executeTest(ctx context.Context, k *kubernetes.Kubernetes, plan *TestPlan) 
 				}
 
 				// Launch ephemeral container to execute the test
-				probedPod, probeContainerName, err := k.LaunchEphemeralContainer(ctx, &pod, command, arguments)
+				probedPod, probeContainerName, err := k.LaunchEphemeralContainer(ctx, &pod, netHaxProbeContainer, command, arguments)
 				if err != nil {
 					indent(3, "Error: Failed to launch ephemeral probe container: %v", err)
 					fmt.Println()

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -84,7 +84,7 @@ func chooseTargetContainer(pod *corev1.Pod) string {
 	return pod.Spec.Containers[0].Name
 }
 
-func (k *Kubernetes) LaunchEphemeralContainer(ctx context.Context, pod *corev1.Pod, command []string, args []string) (*corev1.Pod, string, error) {
+func (k *Kubernetes) LaunchEphemeralContainer(ctx context.Context, pod *corev1.Pod, nethaxProbeContainer string, command []string, args []string) (*corev1.Pod, string, error) {
 	podJS, err := json.Marshal(pod)
 	if err != nil {
 		return nil, "", fmt.Errorf("error creating JSON for pod: %v", err)
@@ -95,7 +95,7 @@ func (k *Kubernetes) LaunchEphemeralContainer(ctx context.Context, pod *corev1.P
 	debugContainer := &corev1.EphemeralContainer{
 		EphemeralContainerCommon: corev1.EphemeralContainerCommon{
 			Name:    ephemeralName,
-			Image:   fmt.Sprintf("nethax-probe:%s", ProbeImageVersion),
+			Image:   fmt.Sprintf("%s:%s", nethaxProbeContainer, ProbeImageVersion),
 			Command: command,
 			Args:    args,
 		},

--- a/pkg/kubernetes/kubernetes_test.go
+++ b/pkg/kubernetes/kubernetes_test.go
@@ -65,7 +65,7 @@ func TestLaunchEphemeralContainer(t *testing.T) {
 	k.Client.CoreV1().Pods(name).Create(t.Context(), pod, metav1.CreateOptions{})
 
 	// execute
-	actual, _, _ := k.LaunchEphemeralContainer(t.Context(), pod, []string{"nyaa"}, []string{"rawr"})
+	actual, _, _ := k.LaunchEphemeralContainer(t.Context(), pod, "grafana/nethax-probe", []string{"nyaa"}, []string{"rawr"})
 
 	// assert
 	if len(actual.Spec.EphemeralContainers) != 1 {


### PR DESCRIPTION
This makes the probe container image configurable by a flag in the runner. It defaults to `grafana/nethax`.
