### PR TITLE
Choose target container by name

### DIFF
--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -89,6 +89,9 @@ func (k *Kubernetes) GetPods(ctx context.Context, namespace, selector string) ([
 	return pods.Items, nil
 }
 
+// chooseTargetContainer returns the container name if found, or the
+// first container name if no name is specified, erroring when no
+// containers are found with that name or if the list is empty.
 func chooseTargetContainer(pod *corev1.Pod, name string) (string, error) {
 	if len(pod.Spec.Containers) == 0 {
 		return "", errNoContainersInPod


### PR DESCRIPTION
## Description

This PR changes `chooseTargetContainer` to allow searching for the target container by name, defaulting to the first container in the pod if no name is specified. We currently don't support indicating the target container name in the test plan file, so while we change the backing function we still pass `""` to pick the first container.

## Changes

- add unit tests for `chooseTargetContainer`
- refactor `chooseTargetContainer` to accept an optional container name

## Testing

Added table tests for testing finding a container by name, failing when not found, and defaulting to the first container if no name is specified.

## Special Considerations

This doesn't change the current design of picking the first container, just adds future capabilities.

## Checklist

- [x] My changes are minimal and accurately solve an identified problem
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
