### PR TITLE
fix: Renovate should tidy up after itself

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "postUpdateOptions": [
+    "gomodTidy"
   ]
 }


### PR DESCRIPTION
## Description
Renovate is opening PRs that don't pass our tidiness check. This should fix it.

Relevant docs:
https://docs.renovatebot.com/configuration-options/\#postupdateoptions
https://docs.renovatebot.com/golang/\#module-tidying

## Changes
Configures Renovate to run a `go mod tidy` after updating.

## Testing
I ran `make test kind-init-otel-demo run-example-test-plan` and everything worked fine :+1:

## Checklist
- [x] My changes are minimal and accurately solve an identified problem
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
