### PR TITLE
Push Tags to Docker Hub

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,21 +2,12 @@ name: Build and Push Image
 
 on:
   push:
-    branches:
-      - main
     tags:
       - v*
 
 permissions:
   contents: read
   id-token: write
-
-env:
-  REGISTRY_IMAGE: grafana/nethax
-  TAGS_CONFIG: |
-    type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
-    type=sha,prefix={{ branch }}-,format=short,enable=${{ github.ref == 'refs/heads/main' }}
-    type=semver,pattern={{ version }}
 
 jobs:
   docker:
@@ -26,21 +17,7 @@ jobs:
         with:
           persist-credentials: false
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Build and push - Probe
-        uses: grafana/shared-workflows/actions/build-push-to-dockerhub@402975d84dd3fac9ba690f994f412d0ee2f51cf4 # build-push-to-dockerhub-v0.1.1
-        with:
-          repository: ${{ env.REGISTRY_IMAGE }}
-          context: .
-          push: true
-          file: Dockerfile-probe
-          platforms: linux/amd64
-          tags: ${{ env.TAGS_CONFIG }}
-      - name: Build and push - Runner
-        uses: grafana/shared-workflows/actions/build-push-to-dockerhub@402975d84dd3fac9ba690f994f412d0ee2f51cf4 # build-push-to-dockerhub-v0.1.1
-        with:
-          repository: ${{ env.REGISTRY_IMAGE }}
-          context: .
-          push: true
-          file: Dockerfile-runner
-          platforms: linux/amd64
-          tags: ${{ env.TAGS_CONFIG }}
+      - name: Dockerhub Login
+        uses: grafana/shared-workflows/actions/dockerhub-login@49c90b10fcbce463983bed45932cf468b8bd06ce # dockerhub-login latest
+      - name: Build and push
+        run: make docker-build docker-push

--- a/Makefile
+++ b/Makefile
@@ -47,8 +47,11 @@ KIND_CLUSTER_NAME ?= "nethax"
 deps:
 	go mod download
 
-.PHONY: docker docker-runner docker-probe
-docker: docker-runner docker-probe
+.PHONY: docker-build docker-push docker-runner docker-probe
+docker-build: docker-runner docker-probe
+
+docker-push:
+	@docker push nethax-runner:$(RUNNER_VERSION) nethax-runner:latest nethax-probe:$(PROBE_VERSION)  nethax-probe:latest
 
 docker-runner:
 	@docker build -f Dockerfile-runner --build-arg PROBE_VERSION=$(PROBE_VERSION) -t nethax-runner:$(RUNNER_VERSION) -t nethax-runner:latest .
@@ -81,7 +84,7 @@ kind-init-oteldemo:
 # Default test plan path if not overridden
 TEST_PLAN ?= "$(CUR_DIR)example/OtelDemoTestPlan.yaml"
 # Run the example test plan against KIND_CLUSTER_NAME
-run-example-test-plan: docker
+run-example-test-plan: docker-build
 	@echo "Running test plan: $(TEST_PLAN)"
 	@TMP_KUBECONFIG=$$(mktemp) && \
 	kind get kubeconfig --name $(KIND_CLUSTER_NAME) > $$TMP_KUBECONFIG && \

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CI := $(CI)
 
 ifndef CI
 # Check we've got the necessary tools installed...
-EXECUTABLES = go docker kind kubectl
+EXECUTABLES := git go docker kind kubectl
 K := $(foreach exec,$(EXECUTABLES),\
         $(if $(shell which $(exec)), not found , $(error "No $(exec) in PATH")))
 endif
@@ -15,8 +15,12 @@ ifdef CI
 	RUNNER_VERSION := $(RUNNER_SEMVER)
 	PROBE_VERSION := $(PROBE_SEMVER)
 else
-	RUNNER_VERSION := "$(RUNNER_SEMVER)-$(shell date +%s)"
-	PROBE_VERSION := "$(PROBE_SEMVER)-$(shell date +%s)"
+	COMMIT_SHA := $(shell git rev-parse HEAD)
+	WORKING_TREE_SHA := $(shell git ls-files -m -o --exclude-standard \
+		| while read -r file; do stat -c '%n %a' $${file}; done \
+		| sha1sum | tr -s ' ' | tr -d ' -')
+	RUNNER_VERSION := "$(RUNNER_SEMVER)-$(COMMIT_SHA)-$(WORKING_TREE_SHA)"
+	PROBE_VERSION := "$(PROBE_SEMVER)-$(COMMIT_SHA)-$(WORKING_TREE_SHA)"
 endif
 
 CUR_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
@@ -47,13 +51,13 @@ deps:
 docker: docker-runner docker-probe
 
 docker-runner:
-	@docker build -f Dockerfile-runner --build-arg PROBE_VERSION=$(PROBE_VERSION) -t nethax-runner:$(RUNNER_VERSION) .
+	@docker build -f Dockerfile-runner --build-arg PROBE_VERSION=$(PROBE_VERSION) -t nethax-runner:$(RUNNER_VERSION) -t nethax-runner:latest .
 ifndef CI
 	@kind load docker-image --name $(KIND_CLUSTER_NAME) nethax-runner:$(RUNNER_VERSION) || true
 endif
 
 docker-probe:
-	@docker build -f Dockerfile-probe --build-arg PROBE_VERSION=$(PROBE_VERSION) -t nethax-probe:$(PROBE_VERSION) .
+	@docker build -f Dockerfile-probe --build-arg PROBE_VERSION=$(PROBE_VERSION) -t nethax-probe:$(PROBE_VERSION)  -t nethax-probe:latest .
 ifndef CI
 	@kind load docker-image --name $(KIND_CLUSTER_NAME) nethax-probe:$(PROBE_VERSION) || true
 endif


### PR DESCRIPTION
## Description
This improves the docker build + release process:
- We should be able to release tags now
- Docker builds will only happen when there are changes to files or permissions

## Changes
### Docker build
- tags a `latest` image whenever a build is run
- local builds will now use a version number based on the latest commit + any uncommitted changes
- this avoids docker rebuilding in cases when the code hasn't changed :)

### GH Action
- uses the Docker Hub login action
- only run Docker build + push on tags starting with v
- adds docker-push to Makefile
- renames Makefile target docker to docker-build for clarity
- calls make docker-build docker-push in GH action after docker is logged in

## Testing
I ran `act` on the GH actions and they parsed + ran properly.

For the docker build side, I rebuilt the containers a few times with and without local changes and everything seems to work.

## Special Considerations
I won't know for sure if this works until I cut a tag for a release...

## Checklist

- [x] My changes are minimal and accurately solve an identified problem
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
