### PR TITLE
Remove target container name

### DIFF
--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -104,11 +104,6 @@ func (k *Kubernetes) LaunchEphemeralContainer(ctx context.Context, pod *corev1.P
 
 	ephemeralName := fmt.Sprintf("nethax-probe-%v", time.Now().UnixNano())
 
-	targetContainer, err := chooseTargetContainer(pod)
-	if err != nil {
-		return nil, "", fmt.Errorf("choosing target container: %w", err)
-	}
-
 	debugContainer := &corev1.EphemeralContainer{
 		EphemeralContainerCommon: corev1.EphemeralContainerCommon{
 			Name:    ephemeralName,
@@ -116,7 +111,6 @@ func (k *Kubernetes) LaunchEphemeralContainer(ctx context.Context, pod *corev1.P
 			Command: command,
 			Args:    args,
 		},
-		TargetContainerName: targetContainer,
 	}
 
 	debugPod := pod.DeepCopy()

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -68,10 +68,7 @@ type Kubernetes struct {
 	client kubernetes.Interface
 }
 
-var (
-	errNoPodsFound       = errors.New("no pods found")
-	errNoContainersInPod = errors.New("no containers in pod")
-)
+var errNoPodsFound = errors.New("no pods found")
 
 func (k *Kubernetes) GetPods(ctx context.Context, namespace, selector string) ([]corev1.Pod, error) {
 	pods, err := k.client.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
@@ -86,14 +83,6 @@ func (k *Kubernetes) GetPods(ctx context.Context, namespace, selector string) ([
 	}
 
 	return pods.Items, nil
-}
-
-func chooseTargetContainer(pod *corev1.Pod) (string, error) {
-	// TODO add capability to pick container by name (currently assume 0th container)
-	if len(pod.Spec.Containers) == 0 {
-		return "", errNoContainersInPod
-	}
-	return pod.Spec.Containers[0].Name, nil
 }
 
 func (k *Kubernetes) LaunchEphemeralContainer(ctx context.Context, pod *corev1.Pod, command []string, args []string) (*corev1.Pod, string, error) {


### PR DESCRIPTION
[here]: #61 (review)## Description
This field is optional, and we only care about sharing the networking namespace.

## Changes
Remove passing `TargetContainerName` when creating an ephemeral container.

## Testing
Tested by running `make checks test run-example-test-plan`.

## Special Considerations
See [here](https://github.com/grafana/nethax/pull/61#pullrequestreview-2859107887) for additional details.

## Checklist

- [x] My changes are minimal and accurately solve an identified problem
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [ ] ~~I have updated the documentation accordingly~~
- [x] My changes generate no new warnings
