### PR TITLE
Fix TCP probe success test

### DIFF
--- a/cmd/probe/tcp_probe_test.go
+++ b/cmd/probe/tcp_probe_test.go
@@ -14,11 +14,24 @@ func TestTCPProbe(t *testing.T) {
 			t.Fatalf("unexpected error creating listener: %v", err)
 		}
 
-		p := NewTCPProbe(l.Addr().String(), false)
+		t.Run("should connect", func(t *testing.T) {
+			p := NewTCPProbe(l.Addr().String(), false)
 
-		if err := p.Run(t.Context()); err != nil {
-			t.Fatal(err)
-		}
+			if err := p.Run(t.Context()); err != nil {
+				t.Fatal(err)
+			}
+		})
+
+		t.Run("should not connect", func(t *testing.T) {
+			if err := l.Close(); err != nil {
+				t.Fatalf("unexpected error closing listener: %v", err)
+			}
+			p := NewTCPProbe(l.Addr().String(), true)
+
+			if err := p.Run(t.Context()); err != nil {
+				t.Fatal(err)
+			}
+		})
 	})
 
 	t.Run("conn should fail", func(t *testing.T) {


### PR DESCRIPTION
## Description
We were missing testing the case when the TCP probe can't dial to an address and we were expecting it to actually fail.

## Changes
Add fixing test case in `cmd/probe/tcp_probe_test.go`.

## Testing
Close the listener before attempting to run a probe that expects the connection to fail.

## Special Considerations
N/A

## Checklist

- [x] My changes are minimal and accurately solve an identified problem
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] ~~I have updated the documentation accordingly~~
- [x] My changes generate no new warnings
