### PR TITLE
fix: Docker Hub pushes should use a proper push command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,10 @@ deps:
 docker-build: docker-runner docker-probe
 
 docker-push:
-	@docker push nethax-runner:$(RUNNER_VERSION) nethax-runner:latest nethax-probe:$(PROBE_VERSION)  nethax-probe:latest
+	@docker push nethax-runner:$(RUNNER_VERSION)
+	@docker push nethax-runner:latest
+	@docker push nethax-probe:$(PROBE_VERSION)
+	@docker push nethax-probe:latest
 
 docker-runner:
 	@docker build -f Dockerfile-runner --build-arg PROBE_VERSION=$(PROBE_VERSION) -t nethax-runner:$(RUNNER_VERSION) -t nethax-runner:latest .

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ ifndef CI
 endif
 
 docker-probe:
-	@docker build -f Dockerfile-probe --build-arg PROBE_VERSION=$(PROBE_VERSION) -t nethax-probe:$(PROBE_VERSION)  -t nethax-probe:latest .
+	@docker build -f Dockerfile-probe --build-arg PROBE_VERSION=$(PROBE_VERSION) -t nethax-probe:$(PROBE_VERSION) -t nethax-probe:latest .
 ifndef CI
 	@kind load docker-image --name $(KIND_CLUSTER_NAME) nethax-probe:$(PROBE_VERSION) || true
 endif


### PR DESCRIPTION
## Description
The previous attempt to push docker images used a push command that didn't conform to the docs:
https://docs.docker.com/reference/cli/docker/image/push/

## Changes
- fix: Properly push the tagged images to the registry
- fix: Whitespace

## Testing
Ran `make docker-build docker-push` locally and got permission issues pushing to Docker Hub -- will test further once this is merged to `main`.

## Special Considerations
Since this is a change to CI, I may need to iterate on this change with a few follow up PRs -- but since we've never pushed an image to Docker Hub it should be safe. Once this is done, I'll document the release process for nethax.

## Checklist
- [x] My changes are minimal and accurately solve an identified problem
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [ ] ~I have updated the documentation accordingly~
- [x] My changes generate no new warnings
