### PR TITLE
fix: Add `PodSelector.String` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,7 @@ Executing test plan: Otel Demo Test Plan
 Description: Test plan for the opentelemetry demo application: https://github.com/open-telemetry/opentelemetry-demo
 
 Executing tests for target: basic connectivity tests
-  Pod Selector: app.kubernetes.io/instance=opentelemetry-demo
-  Pod Selection Mode: random
+  Pod Selector: mode: random, labels: app.kubernetes.io/instance=opentelemetry-demo
   Selected 1 ready pod(s) for testing
   Testing pod: otel-demo/frontend-6769b58884-vw62t
     Executing test: Check internet access
@@ -66,9 +65,8 @@ Executing tests for target: basic connectivity tests
       Result: PASSED
 
 Executing tests for target: coredns connectivity tests
-  Pod Selector: k8s-app=kube-dns
+  Pod Selector: mode: all, labels: k8s-app=kube-dns
   Namespace: kube-system
-  Pod Selection Mode: all
   Selected 2 ready pod(s) for testing
   Testing pod: kube-system/coredns-7c65d6cfc9-dbrv8
     Executing test: Ensure fake service call fails

--- a/cmd/runner/executetest.go
+++ b/cmd/runner/executetest.go
@@ -81,7 +81,6 @@ func executeTest(ctx context.Context, k *kubernetes.Kubernetes, plan *TestPlan) 
 		if target.Namespace != "" {
 			indent(1, "Namespace: %s", target.Namespace)
 		}
-		indent(1, "Selection Mode: %s", target.PodSelector.Mode)
 
 		selectedPods, err := findPods(ctx, k, target.Namespace, target.PodSelector)
 		if err != nil {

--- a/cmd/runner/testplan.go
+++ b/cmd/runner/testplan.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"io"
+	"strings"
 	"time"
 
 	"github.com/goccy/go-yaml"
@@ -22,6 +23,23 @@ type PodSelector struct {
 	Mode   string `yaml:"mode"` // "all" or "random"
 	Labels string `yaml:"labels"`
 	Fields string `yaml:"fields"`
+}
+
+func (s PodSelector) String() string {
+	var b strings.Builder
+	b.WriteString("mode: ")
+	b.WriteString(s.Mode)
+
+	if s.Labels != "" {
+		b.WriteString(", labels: ")
+		b.WriteString(s.Labels)
+	}
+	if s.Fields != "" {
+		b.WriteString(", fields: ")
+		b.WriteString(s.Fields)
+	}
+
+	return b.String()
 }
 
 // TestTarget represents a pod target with multiple tests

--- a/cmd/runner/testplan_test.go
+++ b/cmd/runner/testplan_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	_ "embed"
+	"fmt"
 	"strings"
 	"testing"
 )
@@ -38,4 +39,29 @@ func TestParseTestPlan(t *testing.T) {
 			t.Fatalf("expecting type to be %q, got %q", e, g)
 		}
 	})
+}
+
+func TestPodSelector_String(t *testing.T) {
+	tests := []struct {
+		sel PodSelector
+		exp string
+	}{
+		{PodSelector{Mode: "all"}, "mode: all"},
+		{PodSelector{Mode: "random"}, "mode: random"},
+
+		{PodSelector{Mode: "all", Labels: "app=nethax"}, "mode: all, labels: app=nethax"},
+		{PodSelector{Mode: "all", Fields: "spec.nodeName=foo-bar-42"}, "mode: all, fields: spec.nodeName=foo-bar-42"},
+		{PodSelector{Mode: "all", Labels: "app=nethax", Fields: "spec.nodeName=foo-bar-42"}, "mode: all, labels: app=nethax, fields: spec.nodeName=foo-bar-42"},
+
+		{PodSelector{Mode: "random", Labels: "app=grafana"}, "mode: random, labels: app=grafana"},
+		{PodSelector{Mode: "random", Fields: "spec.nodeName=foo-bar-23"}, "mode: random, fields: spec.nodeName=foo-bar-23"},
+		{PodSelector{Mode: "random", Labels: "app=grafana", Fields: "spec.nodeName=foo-bar-23"}, "mode: random, labels: app=grafana, fields: spec.nodeName=foo-bar-23"},
+	}
+
+	for _, tt := range tests {
+		// using fmt.Sprint here so we know it uses Stringer
+		if got := fmt.Sprint(tt.sel); tt.exp != got {
+			t.Errorf("for %#v expecting %q, got %q", tt.sel, tt.exp, got)
+		}
+	}
 }


### PR DESCRIPTION
## Description
Previously when we were printing the selector in the test execution,
it was looking something like the following:

    Selector: {all k8s-app=kube-dns }
    Namespace: kube-system
    Selection Mode: all

This is using the default format Go uses for structs, which is not
very human readable, and could be confusing of both labels and fields
are used. With this new method, the above message would look like:

    Selector: mode: all, labels: k8s-app=kube-dns
    Namespace: kube-system

Additionally, if fields were also used, it would look like:

    Selector: mode: all, labels: k8s-app=kube-dns, fields: spec.nodeName=foo-bar-42
    Namespace: kube-system
## Changes
Implement [`fmt.Stringer`](https://pkg.go.dev/fmt#Stringer) interface for `PodSelector`.

## Testing
Add tests for different `PodSelector` values and compare against the expected output.

## Special Considerations
Test output changed by removing a duplicated line.

## Checklist

- [x] My changes are minimal and accurately solve an identified problem
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
