### PR TITLE
fix: Enable Renovate automerge

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,3 +22,11 @@ Once you've installed the OpenTelemetry Demo, you can execute the example test p
 ```
 make run-example-test-plan
 ```
+# Dependencies
+Renovate is used for dependency management.
+
+Some non-default things we do with Renovate:
+- Run `god mod tidy` after updating Go modules
+- Automerge is enabled -- PRs must be approved by a CODEOWNER and pass checks to be merged
+
+See the Renovate config for the latest config. :)

--- a/renovate.json
+++ b/renovate.json
@@ -5,5 +5,6 @@
   ],
   "postUpdateOptions": [
     "gomodTidy"
-  ]
+  ],
+  "automerge": true
 }


### PR DESCRIPTION
## Description
Renovate should use automerge so that PRs are merged by Renovate once checks are passing and the PR has been approved. This change will cause Renovate to enable automerge on PRs it creates.

## Changes
- Enables automerge in Renovate config

## Testing
N/A (will test next time Renovate runs)

## Special Considerations
Relevant docs: https://docs.renovatebot.com/configuration-options/#automerge

## Checklist
- [x] My changes are minimal and accurately solve an identified problem
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
