### PR TITLE
fix: Cross-platform dev version using git magicks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,12 +15,9 @@ ifdef CI
 	RUNNER_VERSION := $(RUNNER_SEMVER)
 	PROBE_VERSION := $(PROBE_SEMVER)
 else
-	COMMIT_SHA := $(shell git rev-parse HEAD)
-	WORKING_TREE_SHA := $(shell git ls-files -m -o --exclude-standard \
-		| while read -r file; do stat -c '%n %a' $${file}; done \
-		| sha1sum | tr -s ' ' | tr -d ' -')
-	RUNNER_VERSION := "$(RUNNER_SEMVER)-$(COMMIT_SHA)-$(WORKING_TREE_SHA)"
-	PROBE_VERSION := "$(PROBE_SEMVER)-$(COMMIT_SHA)-$(WORKING_TREE_SHA)"
+	WORKING_TREE_SHA := $(shell hack/get-worktree-sha.sh)
+	RUNNER_VERSION := "$(RUNNER_SEMVER)-$(WORKING_TREE_SHA)"
+	PROBE_VERSION := "$(PROBE_SEMVER)-$(WORKING_TREE_SHA)"
 endif
 
 RUNNER_IMAGE_PREFIX := "grafana/nethax-runner"

--- a/hack/get-worktree-sha.sh
+++ b/hack/get-worktree-sha.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# Get the SHA of the working tree including all uncommitted changes.
+
+# FOR DEBUG
+# set -x
+
+# Script should fail on errors, errors in pipes, or access to unset variables
+set -o errexit -o pipefail -o nounset
+
+# Create a temporary file path (just the path)
+TF=$(mktemp)
+
+# Remove the file (git requires an empty file)
+rm -f $TF
+
+# Copy the current git index to our temp location
+cp .git/index $TF
+
+# Stage all files using the temporary index (suppress warnings)
+GIT_INDEX_FILE=$TF git add . &>/dev/null
+# Generate the tree SHA from the temporary index
+GIT_INDEX_FILE=$TF git write-tree


### PR DESCRIPTION
## Description
This modifies how the dev version is generated when building nethax locally. 

In #69 -- the dev version generation was modified to not use a timestamp to avoid docker builds. However, this introduced issues with Mac and Windows dev experience.

This fixes the problem and uses only git.

## Changes
- Introduces `hack` directory has per [Kubernetes conventions](https://github.com/kubernetes/kubernetes/tree/master/hack#kubernetes-hack-guidelines)
- Uses `get-worktree-sha.sh` to generate the development version
  - This script uses a temporary git index to get the SHA that would be produced if a `git add . && git commit -am` were run :)

## Testing
I've tested locally with `make docker-build` and it seems to work.

## Special Considerations
I'm running this on Linux, so tests from MacOS and Windows would be appreciated!

## Checklist
- [x] My changes are minimal and accurately solve an identified problem
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
