### PR TITLE
Adds Configurability for Probe Images

### DIFF
--- a/Dockerfile-probe
+++ b/Dockerfile-probe
@@ -9,8 +9,8 @@ COPY [".", "."]
 RUN ["go", "mod", "download"]
 
 # Build the probe binary
-ARG PROBE_VERSION
-RUN env CGO_ENABLED=0 GOOS=linux go build -ldflags="-w -s -extldflags '-static' -X 'github.com/grafana/nethax/pkg/kubernetes.ProbeImageVersion=${PROBE_VERSION}'" -a -o /probe ./cmd/probe
+ARG PROBE_IMAGE
+RUN env CGO_ENABLED=0 GOOS=linux go build -ldflags="-w -s -extldflags '-static' -X 'github.com/grafana/nethax/pkg/kubernetes.DefaultProbeImage=${PROBE_IMAGE}'" -a -o /probe ./cmd/probe
 
 FROM scratch
 

--- a/Dockerfile-runner
+++ b/Dockerfile-runner
@@ -9,8 +9,8 @@ COPY [".", "."]
 RUN ["go", "mod", "download"]
 
 # Build the probe binary
-ARG PROBE_VERSION
-RUN env CGO_ENABLED=0 GOOS=linux go build -ldflags="-w -s -extldflags '-static' -X 'github.com/grafana/nethax/pkg/kubernetes.ProbeImageVersion=${PROBE_VERSION}'" -a -o /runner ./cmd/runner
+ARG PROBE_IMAGE
+RUN env CGO_ENABLED=0 GOOS=linux go build -ldflags="-w -s -extldflags '-static' -X 'github.com/grafana/nethax/pkg/kubernetes.DefaultProbeImage=${PROBE_IMAGE}'" -a -o /runner ./cmd/runner
 
 FROM scratch
 

--- a/Makefile
+++ b/Makefile
@@ -33,10 +33,10 @@ export GOEXPERIMENT=synctest
 build: build-runner build-probe
 
 build-runner: deps-runner
-	go build -ldflags="-X 'github.com/grafana/nethax/pkg/kubernetes.ProbeImageVersion=$(PROBE_VERSION)'" -o "$(CUR_DIR)/bin" $(DIR_RUNNER)
+	go build -ldflags="-X 'github.com/grafana/nethax/pkg/kubernetes.DefaultProbeImage=$(PROBE_IMAGE_PREFIX):$(PROBE_VERSION)'" -o "$(CUR_DIR)/bin" $(DIR_RUNNER)
 
 build-probe: deps-probe
-	go build -ldflags="-X 'github.com/grafana/nethax/pkg/kubernetes.ProbeImageVersion=$(PROBE_VERSION)'" -o "$(CUR_DIR)/bin" $(DIR_PROBE)
+	go build -ldflags="-X 'github.com/grafana/nethax/pkg/kubernetes.DefaultProbeImage=$(PROBE_IMAGE_PREFIX):$(PROBE_VERSION)'" -o "$(CUR_DIR)/bin" $(DIR_PROBE)
 
 .PHONY: clean
 clean:
@@ -60,13 +60,13 @@ docker-push:
 	@docker push $(PROBE_IMAGE_PREFIX):latest
 
 docker-runner:
-	@docker build -f Dockerfile-runner --build-arg PROBE_VERSION=$(PROBE_VERSION) -t $(RUNNER_IMAGE_PREFIX):$(RUNNER_VERSION) -t $(RUNNER_IMAGE_PREFIX):latest .
+	@docker build -f Dockerfile-runner --build-arg PROBE_IMAGE=$(PROBE_IMAGE_PREFIX):$(PROBE_VERSION) -t $(RUNNER_IMAGE_PREFIX):$(RUNNER_VERSION) -t $(RUNNER_IMAGE_PREFIX):latest .
 ifndef CI
 	@kind load docker-image --name $(KIND_CLUSTER_NAME) $(RUNNER_IMAGE_PREFIX):$(RUNNER_VERSION) || true
 endif
 
 docker-probe:
-	@docker build -f Dockerfile-probe --build-arg PROBE_VERSION=$(PROBE_VERSION) -t $(PROBE_IMAGE_PREFIX):$(PROBE_VERSION) -t $(PROBE_IMAGE_PREFIX):latest .
+	@docker build -f Dockerfile-probe --build-arg PROBE_IMAGE=$(PROBE_IMAGE_PREFIX):$(PROBE_VERSION) -t $(PROBE_IMAGE_PREFIX):$(PROBE_VERSION) -t $(PROBE_IMAGE_PREFIX):latest .
 ifndef CI
 	@kind load docker-image --name $(KIND_CLUSTER_NAME) $(PROBE_IMAGE_PREFIX):$(PROBE_VERSION) || true
 endif

--- a/Makefile
+++ b/Makefile
@@ -62,13 +62,13 @@ docker-push:
 docker-runner:
 	@docker build -f Dockerfile-runner --build-arg PROBE_VERSION=$(PROBE_VERSION) -t $(RUNNER_IMAGE_PREFIX):$(RUNNER_VERSION) -t $(RUNNER_IMAGE_PREFIX):latest .
 ifndef CI
-	@kind load docker-image --name $(KIND_CLUSTER_NAME) nethax-runner:$(RUNNER_VERSION) || true
+	@kind load docker-image --name $(KIND_CLUSTER_NAME) $(RUNNER_IMAGE_PREFIX):$(RUNNER_VERSION) || true
 endif
 
 docker-probe:
 	@docker build -f Dockerfile-probe --build-arg PROBE_VERSION=$(PROBE_VERSION) -t $(PROBE_IMAGE_PREFIX):$(PROBE_VERSION) -t $(PROBE_IMAGE_PREFIX):latest .
 ifndef CI
-	@kind load docker-image --name $(KIND_CLUSTER_NAME) nethax-probe:$(PROBE_VERSION) || true
+	@kind load docker-image --name $(KIND_CLUSTER_NAME) $(PROBE_IMAGE_PREFIX):$(PROBE_VERSION) || true
 endif
 
 .PHONY: test
@@ -100,7 +100,7 @@ run-example-test-plan: docker-build
 		--mount "type=bind,source=$(TEST_PLAN),target=/test-plan.yaml,readonly" \
 		-e "KUBECONFIG=/.kube/config" \
 		--user $(id -u):$(id -g) \
-		nethax-runner:$(RUNNER_VERSION) "execute-test" "-f" "/test-plan.yaml"; \
+		$(RUNNER_IMAGE_PREFIX):$(RUNNER_VERSION) "execute-test" "-f" "/test-plan.yaml"; \
 	rm -rf $$TMP_KUBECONFIG
 
 .PHONY: checks

--- a/cmd/runner/executetest.go
+++ b/cmd/runner/executetest.go
@@ -137,9 +137,7 @@ func executeTest(ctx context.Context, k *kubernetes.Kubernetes, plan *TestPlan, 
 				if probeImage == "" {
 					probeImage = defaultProbeImage
 				}
-				if probeImage != "" {
-					indent(3, "Probe Image: %s", probeImage)
-				}
+				indent(3, "Probe Image: '%s'", probeImage)
 
 				// Launch ephemeral container to execute the test
 				probedPod, probeContainerName, err := k.LaunchEphemeralContainer(ctx, &pod, probeImage, command, arguments)

--- a/cmd/runner/executetest.go
+++ b/cmd/runner/executetest.go
@@ -19,6 +19,7 @@ import (
 // ExecuteTest returns the execute-test command
 func ExecuteTest() *cobra.Command {
 	var testFile string
+	var probeImage string
 
 	cmd := &cobra.Command{
 		Use:   "execute-test -f example/OtelDemoTestPlan.yaml",
@@ -49,6 +50,11 @@ func ExecuteTest() *cobra.Command {
 				os.Exit(exitCodeConfigError)
 			}
 
+			// Set custom probe image if provided
+			if probeImage != "" {
+				k.SetProbeImage(probeImage)
+			}
+
 			if !executeTest(cmd.Context(), k, plan) {
 				os.Exit(exitCodeFailure)
 			}
@@ -57,6 +63,7 @@ func ExecuteTest() *cobra.Command {
 
 	cmd.Flags().StringVarP(&testFile, "file", "f", "", "Path to the test configuration YAML file")
 	cmd.MarkFlagRequired("file") //nolint:errcheck
+	cmd.Flags().StringVar(&probeImage, "probe-image", "", fmt.Sprintf("Probe image to use for ephemeral probe containers (defaults to grafana/nethax-probe:%s')", kubernetes.ProbeImageVersion))
 
 	return cmd
 }

--- a/cmd/runner/executetest.go
+++ b/cmd/runner/executetest.go
@@ -69,7 +69,7 @@ func indent(level int, format string, a ...any) {
 	fmt.Println()
 }
 
-func executeTest(ctx context.Context, k *kubernetes.Kubernetes, plan *TestPlan, defaultProbeImage string) bool {
+func executeTest(ctx context.Context, k *kubernetes.Kubernetes, plan *TestPlan, probeImageFlag string) bool {
 	indent(0, "Test Plan: %s", plan.Name)
 	indent(0, "Description: %s", plan.Description)
 	fmt.Println()
@@ -135,9 +135,9 @@ func executeTest(ctx context.Context, k *kubernetes.Kubernetes, plan *TestPlan, 
 				// Determine which probe image to use
 				probeImage := test.ProbeImage
 				if probeImage == "" {
-					probeImage = defaultProbeImage
+					probeImage = probeImageFlag
 				}
-				indent(3, "Probe Image: '%s'", probeImage)
+				indent(3, "Probe Image: '%s'", kubernetes.GetProbeImage(probeImage))
 
 				// Launch ephemeral container to execute the test
 				probedPod, probeContainerName, err := k.LaunchEphemeralContainer(ctx, &pod, probeImage, command, arguments)

--- a/cmd/runner/executetest.go
+++ b/cmd/runner/executetest.go
@@ -74,7 +74,7 @@ func indent(level int, format string, a ...any) {
 	fmt.Println()
 }
 
-func executeTest(ctx context.Context, k *kubernetes.Kubernetes, plan *TestPlan, probeImageFlag string) bool {
+func executeTest(ctx context.Context, k *kubernetes.Kubernetes, plan *TestPlan) bool {
 	indent(0, "Test Plan: %s", plan.Name)
 	indent(0, "Description: %s", plan.Description)
 	fmt.Println()

--- a/cmd/runner/executetest.go
+++ b/cmd/runner/executetest.go
@@ -51,7 +51,7 @@ func ExecuteTest() *cobra.Command {
 			}
 
 			kubernetes.DefaultProbeImage = defaultProbeImage
-			if !executeTest(cmd.Context(), k, plan, defaultProbeImage) {
+			if !executeTest(cmd.Context(), k, plan) {
 				os.Exit(exitCodeFailure)
 			}
 		},

--- a/cmd/runner/executetest.go
+++ b/cmd/runner/executetest.go
@@ -58,7 +58,7 @@ func ExecuteTest() *cobra.Command {
 
 	cmd.Flags().StringVarP(&testFile, "file", "f", "", "Path to the test configuration YAML file")
 	cmd.MarkFlagRequired("file") //nolint:errcheck
-	cmd.Flags().StringVar(&probeImage, "probe-image", "", fmt.Sprintf("Probe image to use for ephemeral probe containers (defaults to grafana/nethax-probe:%s')", kubernetes.ProbeImageVersion))
+	cmd.Flags().StringVar(&probeImage, "probe-image", "", fmt.Sprintf("Default probe image to use if test plan doesn't specify one (defaults to grafana/nethax-probe:%s')", kubernetes.ProbeImageVersion))
 
 	return cmd
 }

--- a/cmd/runner/executetest.go
+++ b/cmd/runner/executetest.go
@@ -137,12 +137,10 @@ func executeTest(ctx context.Context, k *kubernetes.Kubernetes, plan *TestPlan) 
 					}
 				}
 
-				// Determine which probe image to use
-				probeImage := kubernetes.GetProbeImage(test.ProbeImage)
-				indent(3, "Probe Image: '%s'", probeImage)
+				indent(3, "Probe Image: '%s'", kubernetes.GetProbeImage(test.ProbeImage))
 
 				// Launch ephemeral container to execute the test
-				probedPod, probeContainerName, err := k.LaunchEphemeralContainer(ctx, &pod, probeImage, command, arguments)
+				probedPod, probeContainerName, err := k.LaunchEphemeralContainer(ctx, &pod, test.ProbeImage, command, arguments)
 				if err != nil {
 					indent(3, "Error: Failed to launch ephemeral probe container: %v", err)
 					fmt.Println()

--- a/cmd/runner/testdata/example.yml
+++ b/cmd/runner/testdata/example.yml
@@ -15,6 +15,11 @@ testPlan:
       endpoint: "http://otel-collector.otel-demo.svc.cluster.local:8888/metrics"
       statusCode: 200
       timeout: 3s
+    - name: "Check with custom probe image"
+      endpoint: "https://example.com"
+      statusCode: 200
+      timeout: 5s
+      probeImage: "myregistry.io/custom-probe:v2.0.0"
   - name: "coredns connectivity tests"
     podSelector:
       labels: "k8s-app=kube-dns"

--- a/cmd/runner/testplan.go
+++ b/cmd/runner/testplan.go
@@ -16,6 +16,7 @@ type Test struct {
 	Type       string        `yaml:"type,omitempty"`
 	ExpectFail bool          `yaml:"expectFail,omitempty"`
 	Timeout    time.Duration `yaml:"timeout"`
+	ProbeImage string        `yaml:"probeImage,omitempty"`
 }
 
 // PodSelector represents how pods should be selected for testing

--- a/cmd/runner/testplan_test.go
+++ b/cmd/runner/testplan_test.go
@@ -26,8 +26,8 @@ func TestParseTestPlan(t *testing.T) {
 		tt := tp.TestTargets[0]
 
 		for i, tt := range tt.Tests {
-			if tt.Type != "HTTP(S)" && tt.Type != "tcp" {
-				t.Errorf("expecting test target 0, test %d to be of type HTTP(S) or tcp, got %q", i, tt.Type)
+			if tt.Type != "HTTP(S)" {
+				t.Errorf("expecting test target 0, test %d to be of type HTTP(S), got %q", i, tt.Type)
 			}
 		}
 	})

--- a/cmd/runner/testplan_test.go
+++ b/cmd/runner/testplan_test.go
@@ -26,8 +26,8 @@ func TestParseTestPlan(t *testing.T) {
 		tt := tp.TestTargets[0]
 
 		for i, tt := range tt.Tests {
-			if tt.Type != "HTTP(S)" {
-				t.Errorf("expecting test target 0, test %d to be of type HTTP(S), got %q", i, tt.Type)
+			if tt.Type != "HTTP(S)" && tt.Type != "tcp" {
+				t.Errorf("expecting test target 0, test %d to be of type HTTP(S) or tcp, got %q", i, tt.Type)
 			}
 		}
 	})
@@ -37,6 +37,20 @@ func TestParseTestPlan(t *testing.T) {
 
 		if e, g := "tcp", tt.Type; e != g {
 			t.Fatalf("expecting type to be %q, got %q", e, g)
+		}
+	})
+
+	t.Run("parse probe image", func(t *testing.T) {
+		// Check that most tests don't have a probe image
+		tt := tp.TestTargets[0].Tests[0]
+		if tt.ProbeImage != "" {
+			t.Errorf("expecting first test to have empty probe image, got %q", tt.ProbeImage)
+		}
+
+		// Check that the test with custom probe image is parsed correctly
+		tt = tp.TestTargets[0].Tests[2]
+		if e, g := "myregistry.io/custom-probe:v2.0.0", tt.ProbeImage; e != g {
+			t.Errorf("expecting probe image to be %q, got %q", e, g)
 		}
 	})
 }

--- a/example/OtelDemoTestPlan.yaml
+++ b/example/OtelDemoTestPlan.yaml
@@ -15,6 +15,7 @@ testPlan:
       endpoint: "http://otel-collector.otel-demo.svc.cluster.local:8888/metrics"
       statusCode: 200
       timeout: 3s
+      # probeImage: "myregistry.io/custom-probe:v1.0.0"  # Optional: override probe image for this test
   - name: "coredns connectivity tests"
     namespace: kube-system
     podSelector:

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -19,7 +19,7 @@ import (
 
 var (
 	// ProbeImageVersion is set at build time via ldflags
-	ProbeImageVersion = "latest"
+	DefaultProbeImage = "grafana/nethax-probe:latest"
 )
 
 // New returns a new Kubernetes object, connected to the given
@@ -89,7 +89,7 @@ func (k *Kubernetes) GetPods(ctx context.Context, namespace, labels, fields stri
 func GetProbeImage(probeImage string) string {
 	// Use the provided probe image, or default if empty
 	if probeImage == "" {
-		probeImage = fmt.Sprintf("grafana/nethax-probe:%s", ProbeImageVersion)
+		probeImage = DefaultProbeImage
 	}
 	return probeImage
 }

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -96,7 +96,7 @@ func (k *Kubernetes) LaunchEphemeralContainer(ctx context.Context, pod *corev1.P
 
 	// Use the provided probe image, or default if empty
 	if probeImage == "" {
-		probeImage = fmt.Sprintf("nethax-probe:%s", ProbeImageVersion)
+		probeImage = fmt.Sprintf("grafana/nethax-probe:%s", ProbeImageVersion)
 	}
 
 	debugContainer := &corev1.EphemeralContainer{

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -36,8 +36,7 @@ func New(context string) (*Kubernetes, error) {
 	}
 
 	return &Kubernetes{
-		client:     client,
-		probeImage: fmt.Sprintf("nethax-probe:%s", ProbeImageVersion),
+		client: client,
 	}, nil
 }
 
@@ -64,8 +63,7 @@ func getClusterConfig(kontext string) (*rest.Config, error) {
 }
 
 type Kubernetes struct {
-	client     kubernetes.Interface
-	probeImage string
+	client kubernetes.Interface
 }
 
 var (
@@ -88,12 +86,7 @@ func (k *Kubernetes) GetPods(ctx context.Context, namespace, labels, fields stri
 	return pods.Items, nil
 }
 
-// SetProbeImage sets the probe image to use for ephemeral containers
-func (k *Kubernetes) SetProbeImage(image string) {
-	k.probeImage = image
-}
-
-func (k *Kubernetes) LaunchEphemeralContainer(ctx context.Context, pod *corev1.Pod, command []string, args []string) (*corev1.Pod, string, error) {
+func (k *Kubernetes) LaunchEphemeralContainer(ctx context.Context, pod *corev1.Pod, probeImage string, command []string, args []string) (*corev1.Pod, string, error) {
 	podJS, err := json.Marshal(pod)
 	if err != nil {
 		return nil, "", fmt.Errorf("error creating JSON for pod: %v", err)
@@ -101,9 +94,7 @@ func (k *Kubernetes) LaunchEphemeralContainer(ctx context.Context, pod *corev1.P
 
 	ephemeralName := fmt.Sprintf("nethax-probe-%v", time.Now().UnixNano())
 
-	// Use the configured probe image
-	probeImage := k.probeImage
-	// If no probe image is set, use the default
+	// Use the provided probe image, or default if empty
 	if probeImage == "" {
 		probeImage = fmt.Sprintf("nethax-probe:%s", ProbeImageVersion)
 	}

--- a/pkg/kubernetes/kubernetes.go
+++ b/pkg/kubernetes/kubernetes.go
@@ -86,6 +86,14 @@ func (k *Kubernetes) GetPods(ctx context.Context, namespace, labels, fields stri
 	return pods.Items, nil
 }
 
+func GetProbeImage(probeImage string) string {
+	// Use the provided probe image, or default if empty
+	if probeImage == "" {
+		probeImage = fmt.Sprintf("grafana/nethax-probe:%s", ProbeImageVersion)
+	}
+	return probeImage
+}
+
 func (k *Kubernetes) LaunchEphemeralContainer(ctx context.Context, pod *corev1.Pod, probeImage string, command []string, args []string) (*corev1.Pod, string, error) {
 	podJS, err := json.Marshal(pod)
 	if err != nil {
@@ -94,15 +102,10 @@ func (k *Kubernetes) LaunchEphemeralContainer(ctx context.Context, pod *corev1.P
 
 	ephemeralName := fmt.Sprintf("nethax-probe-%v", time.Now().UnixNano())
 
-	// Use the provided probe image, or default if empty
-	if probeImage == "" {
-		probeImage = fmt.Sprintf("grafana/nethax-probe:%s", ProbeImageVersion)
-	}
-
 	debugContainer := &corev1.EphemeralContainer{
 		EphemeralContainerCommon: corev1.EphemeralContainerCommon{
 			Name:    ephemeralName,
-			Image:   probeImage,
+			Image:   GetProbeImage(probeImage),
 			Command: command,
 			Args:    args,
 		},

--- a/pkg/kubernetes/kubernetes_test.go
+++ b/pkg/kubernetes/kubernetes_test.go
@@ -143,7 +143,7 @@ func TestLaunchEphemeralContainerWithProbeImage(t *testing.T) {
 		{
 			name:          "default probe image when empty",
 			probeImage:    "",
-			expectedImage: fmt.Sprintf("grafana/nethax-probe:%s", ProbeImageVersion),
+			expectedImage: DefaultProbeImage,
 		},
 		{
 			name:          "custom probe image",

--- a/pkg/kubernetes/kubernetes_test.go
+++ b/pkg/kubernetes/kubernetes_test.go
@@ -141,6 +141,33 @@ func TestLaunchEphemeralContainer(t *testing.T) {
 	k.client.CoreV1().Namespaces().Delete(t.Context(), name, metav1.DeleteOptions{})
 }
 
+func TestSetProbeImage(t *testing.T) {
+	tests := []struct {
+		name  string
+		image string
+	}{
+		{"default image", "nethax-probe:latest"},
+		{"custom image", "custom-registry.io/nethax-probe:v1.2.3"},
+		{"fully qualified image", "gcr.io/project/nethax-probe:abc123"},
+		{"empty image", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			k := &Kubernetes{
+				client:     testClient.NewSimpleClientset(),
+				probeImage: "initial-image",
+			}
+
+			k.SetProbeImage(tt.image)
+
+			if k.probeImage != tt.image {
+				t.Errorf("Expected probeImage to be %q, got %q", tt.image, k.probeImage)
+			}
+		})
+	}
+}
+
 func TestGetEphemeralContainerExitStatus(t *testing.T) {
 	const ephemeralContainerName = "nethaxme"
 

--- a/pkg/kubernetes/kubernetes_test.go
+++ b/pkg/kubernetes/kubernetes_test.go
@@ -143,7 +143,7 @@ func TestLaunchEphemeralContainerWithProbeImage(t *testing.T) {
 		{
 			name:          "default probe image when empty",
 			probeImage:    "",
-			expectedImage: fmt.Sprintf("nethax-probe:%s", ProbeImageVersion),
+			expectedImage: fmt.Sprintf("grafana/nethax-probe:%s", ProbeImageVersion),
 		},
 		{
 			name:          "custom probe image",


### PR DESCRIPTION
## Description
Adds the ability to configure probe images, making it possible to run images in Kubernetes regardless of probe image registry.

## Changes
- add probe image as parameter to launch ephemeral container
- add probe image as flag on the runner
- add per-test probe image config
- simplifies ephemeral container tests -- the code was doing extra setup/teardown that isn't required with our mock
- set the default image to use Docker Hub
- ensure kind loads the fully qualified image name into the control plane
- updates the example YAML and `--help` output messages

## Testing
- Unit tests added
- `make test kind-init-oteldemo run-example-test-plan` works correctly

## Special Considerations
- Implemented as discussed
- Tried to make small commits to make review easier! <3

## Checklist
- [x] My changes are minimal and accurately solve an identified problem
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
