### PR TITLE
fix: Adds test coverage output to Make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ endif
 
 .PHONY: test
 test:
-	@go test ./...
+	@go test -cover ./...
 
 .PHONY: kind-init-oteldemo
 


### PR DESCRIPTION
## Description
I found myself doing this manually to ensure I wasn't reducing overall test coverage with my changes!

## Changes
Just adds test coverage to the output of `make test` :)

## Testing
`make test` works

## Special Considerations
This PR is itty bitty!

## Checklist
- [x] My changes are minimal and accurately solve an identified problem
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [ ] ~I have updated the documentation accordingly~
- [x] My changes generate no new warnings
