### PR TITLE
feat: use custom YAML parsing for enum types

### DIFF
--- a/cmd/runner/executetest.go
+++ b/cmd/runner/executetest.go
@@ -112,7 +112,7 @@ func executeTest(ctx context.Context, k *kubernetes.Kubernetes, plan *TestPlan) 
 				indent(3, "Timeout: %s", test.Timeout.String())
 
 				// Parse the endpoint URL for HTTP tests
-				if test.Type != "tcp" {
+				if test.Type != TestTypeTCP {
 					_, err := url.Parse(test.Endpoint)
 					if err != nil {
 						indent(3, "Error: Invalid endpoint URL: %v", err)
@@ -130,7 +130,7 @@ func executeTest(ctx context.Context, k *kubernetes.Kubernetes, plan *TestPlan) 
 					pf.Flagify(pf.ArgExpectedStatus), strconv.Itoa(test.StatusCode),
 				}
 
-				if test.Type == pf.TestTypeTCP {
+				if test.Type == TestTypeTCP {
 					arguments = append(arguments, pf.Flagify(pf.ArgType), pf.TestTypeTCP)
 					if test.ExpectFail {
 						arguments = append(arguments, pf.Flagify(pf.ArgExpectFail))

--- a/cmd/runner/executetest.go
+++ b/cmd/runner/executetest.go
@@ -197,8 +197,8 @@ var (
 	errNoReadyPods          = errors.New("no ready pods found")
 )
 
-func selectPods(mode string, pods []corev1.Pod) ([]corev1.Pod, error) {
-	if mode := mode; mode != "all" && mode != "random" {
+func selectPods(mode SelectionMode, pods []corev1.Pod) ([]corev1.Pod, error) {
+	if mode != SelectionModeAll && mode != SelectionModeRandom {
 		return nil, fmt.Errorf("%w: %s", errInvalidSelectionMode, mode)
 	}
 
@@ -216,7 +216,7 @@ func selectPods(mode string, pods []corev1.Pod) ([]corev1.Pod, error) {
 	}
 
 	// Select pods based on the selection mode
-	if mode == "random" {
+	if mode == SelectionModeRandom {
 		// Select one random pod from the ready pods
 		randomIndex := rand.Intn(len(selectedPods))
 		selectedPods = []corev1.Pod{selectedPods[randomIndex]}

--- a/cmd/runner/executetest_test.go
+++ b/cmd/runner/executetest_test.go
@@ -128,7 +128,7 @@ func TestSelectPods(t *testing.T) {
 	}
 
 	tests := map[string]struct {
-		mode string
+		mode SelectionMode
 		pods []corev1.Pod
 		exp  []corev1.Pod
 		err  error

--- a/cmd/runner/testplan.go
+++ b/cmd/runner/testplan.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"io"
 	"strings"
 	"time"
@@ -76,4 +77,37 @@ func ParseTestPlan(reader io.Reader) (*TestPlan, error) {
 		}
 	}
 	return &plan.TestPlan, nil
+}
+
+type TestType int
+
+func (tt TestType) String() string {
+	switch tt {
+	case TestTypeHTTP:
+		return "http"
+	case TestTypeTCP:
+		return "tcp"
+	default:
+		panic("unrecognized testype")
+	}
+}
+
+const (
+	TestTypeHTTP TestType = iota
+	TestTypeTCP
+)
+
+var errInvalidTestType = errors.New("invalid test type")
+
+func yamlUnmarshalTestType(tt *TestType, b []byte) error {
+	switch strings.ToLower(string(b)) {
+	case "", "http", "https":
+		*tt = TestTypeHTTP
+	case "tcp":
+		*tt = TestTypeTCP
+	default:
+		return errInvalidTestType
+	}
+
+	return nil
 }

--- a/cmd/runner/testplan.go
+++ b/cmd/runner/testplan.go
@@ -23,15 +23,15 @@ type Test struct {
 
 // PodSelector represents how pods should be selected for testing
 type PodSelector struct {
-	Mode   string `yaml:"mode"` // "all" or "random"
-	Labels string `yaml:"labels"`
-	Fields string `yaml:"fields"`
+	Mode   SelectionMode `yaml:"mode"` // "all" or "random"
+	Labels string        `yaml:"labels"`
+	Fields string        `yaml:"fields"`
 }
 
 func (s PodSelector) String() string {
 	var b strings.Builder
 	b.WriteString("mode: ")
-	b.WriteString(s.Mode)
+	b.WriteString(string(s.Mode))
 
 	if s.Labels != "" {
 		b.WriteString(", labels: ")
@@ -107,6 +107,7 @@ func yamlUnmarshalTestType(tt *TestType, b []byte) error {
 
 func init() {
 	yaml.RegisterCustomUnmarshaler(yamlUnmarshalTestType)
+	yaml.RegisterCustomUnmarshaler(yamlUnmarshalSelectionMode)
 }
 
 type SelectionMode string

--- a/cmd/runner/testplan.go
+++ b/cmd/runner/testplan.go
@@ -108,3 +108,28 @@ func yamlUnmarshalTestType(tt *TestType, b []byte) error {
 func init() {
 	yaml.RegisterCustomUnmarshaler(yamlUnmarshalTestType)
 }
+
+type SelectionMode string
+
+const (
+	SelectionModeAll    SelectionMode = "all"
+	SelectionModeRandom SelectionMode = "random"
+)
+
+func yamlUnmarshalSelectionMode(m *SelectionMode, b []byte) error {
+	// we need to add the cases with quotes because YAML is such a
+	// good language that `foo: bar` is the same as `foo: "bar"` and
+	// also the same as `foo: 'bar'` but, hey, the three values are
+	// passed as-is to the parser and thus have to take into account
+	// these characters.
+	switch strings.TrimSpace(strings.ToLower(string(b))) {
+	case "all", "\"all\"", "'all'":
+		*m = SelectionModeAll
+	case "random", "\"random\"", "'random'":
+		*m = SelectionModeRandom
+	default:
+		return fmt.Errorf("%w: %q", errInvalidSelectionMode, b)
+	}
+
+	return nil
+}

--- a/cmd/runner/testplan.go
+++ b/cmd/runner/testplan.go
@@ -106,7 +106,7 @@ func yamlUnmarshalTestType(tt *TestType, b []byte) error {
 	case "tcp":
 		*tt = TestTypeTCP
 	default:
-		return errInvalidTestType
+		return fmt.Errorf("%w: %q", errInvalidTestType, b)
 	}
 
 	return nil

--- a/cmd/runner/testplan_test.go
+++ b/cmd/runner/testplan_test.go
@@ -119,3 +119,33 @@ func TestTestType_UnmarshalYAML(t *testing.T) {
 		})
 	}
 }
+
+func TestSelectionMode_UnmarshalYAML(t *testing.T) {
+	tests := map[string]struct {
+		exp SelectionMode
+		err error
+	}{
+		// cannot be empty
+		"": {"", errInvalidSelectionMode},
+
+		"all": {SelectionModeAll, nil},
+		"ALL": {SelectionModeAll, nil},
+
+		"random": {SelectionModeRandom, nil},
+		"rAnDom": {SelectionModeRandom, nil},
+	}
+
+	for in, tt := range tests {
+		t.Run("in="+in, func(t *testing.T) {
+			var got SelectionMode
+
+			err := yamlUnmarshalSelectionMode(&got, []byte(in))
+			if !errors.Is(err, tt.err) {
+				t.Fatalf("expecting error %v, got %v", tt.err, err)
+			}
+			if tt.exp != got {
+				t.Fatalf("expecting SelectionMode %q, got %q", tt.exp, got)
+			}
+		})
+	}
+}

--- a/cmd/runner/testplan_test.go
+++ b/cmd/runner/testplan_test.go
@@ -27,7 +27,7 @@ func TestParseTestPlan(t *testing.T) {
 		tt := tp.TestTargets[0]
 
 		for i, tt := range tt.Tests {
-			if tt.Type != "HTTP(S)" {
+			if tt.Type != TestTypeHTTP {
 				t.Errorf("expecting test target 0, test %d to be of type HTTP(S), got %q", i, tt.Type)
 			}
 		}
@@ -36,7 +36,7 @@ func TestParseTestPlan(t *testing.T) {
 	t.Run("don't override type", func(t *testing.T) {
 		tt := tp.TestTargets[1].Tests[1]
 
-		if e, g := "tcp", tt.Type; e != g {
+		if e, g := TestTypeTCP, tt.Type; e != g {
 			t.Fatalf("expecting type to be %q, got %q", e, g)
 		}
 	})


### PR DESCRIPTION
## Description
As described in #79 here we implement two custom types, with custom YAML parsing functions, for test types and pod selection mode. The idea behind it is to make parsing the YAML files containing test plans more robust, by failing the process if any of those fields contains an invalid value.

## Changes
* Add custom `TestType` enum type with YAML unmarshaler.
* Add custom `SelectioMode` enum type with YAML unmarshaler.

## Testing
Add tests for parsing both enum types.

## Special Considerations
For `TestType` the zero value defaults to HTTP. The design decision behind it is that HTTP is the default test type.

## Checklist

- [x] My changes are minimal and accurately solve an identified problem
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
