### PR TITLE
feat: Add `--context` flag to override the Kubernetes cluster

### DIFF
--- a/cmd/runner/executetest.go
+++ b/cmd/runner/executetest.go
@@ -18,9 +18,7 @@ import (
 
 // ExecuteTest returns the execute-test command
 func ExecuteTest() *cobra.Command {
-	var testFile string
-	var defaultProbeImage string
-	var kontext string
+	var testFile, defaultProbeImage, kontext string
 
 	cmd := &cobra.Command{
 		Use:   "execute-test -f example/OtelDemoTestPlan.yaml",

--- a/cmd/runner/executetest.go
+++ b/cmd/runner/executetest.go
@@ -20,6 +20,7 @@ import (
 func ExecuteTest() *cobra.Command {
 	var testFile string
 	var defaultProbeImage string
+	var kontext string
 
 	cmd := &cobra.Command{
 		Use:   "execute-test -f example/OtelDemoTestPlan.yaml",
@@ -44,7 +45,7 @@ func ExecuteTest() *cobra.Command {
 				os.Exit(exitCodeConfigError)
 			}
 
-			k, err := kubernetes.New("")
+			k, err := kubernetes.New(kontext)
 			if err != nil {
 				cmd.Printf("Error creating Kubernetes client: %v\n", err)
 				os.Exit(exitCodeConfigError)
@@ -59,6 +60,9 @@ func ExecuteTest() *cobra.Command {
 
 	cmd.Flags().StringVarP(&testFile, "file", "f", "", "Path to the test configuration YAML file")
 	cmd.MarkFlagRequired("file") //nolint:errcheck
+
+	cmd.Flags().StringVarP(&kontext, "context", "c", "", "Kubernetes context to connect. Leave empty for in-cluster context.")
+
 	cmd.Flags().StringVar(&defaultProbeImage,
 		"default-probe-image",
 		kubernetes.DefaultProbeImage,


### PR DESCRIPTION
## Description
Add `--context/-c` to `cmd/runner` so we can connect directly from a local machine to a Kubernetes cluster in `~/.kube/config`, or in-cluster if left empty.

## Changes
Add `--context` flag.

## Testing
Tried locally against a live cluster.

## Special Considerations
N/A

## Checklist

- [x] My changes are minimal and accurately solve an identified problem
- [x] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
