### PR TITLE
Enable strict YAML parsing

### DIFF
--- a/cmd/runner/testplan.go
+++ b/cmd/runner/testplan.go
@@ -65,7 +65,7 @@ func ParseTestPlan(reader io.Reader) (*TestPlan, error) {
 	var plan struct {
 		TestPlan TestPlan `yaml:"testPlan"`
 	}
-	if err := yaml.NewDecoder(reader).Decode(&plan); err != nil {
+	if err := yaml.NewDecoder(reader, yaml.Strict()).Decode(&plan); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
## Description
While migrating some old test plans I've found that I mistyped a key (`selector` instead of `podSelector`) in the configuration file and the parsing silently succeeded yet the execution failed because some fields weren't properly valued. By passing the strict decoding option parsing will fail if it encounters a field name that isn't recognized, enabling faster and better feedback to users.

## Changes
Use [`yaml.Strict`](https://pkg.go.dev/github.com/goccy/go-yaml#Strict) decoding option.

## Testing
Manually changed the YAML file to change the casing and name of some fields.

## Special Considerations
N/A

## Checklist

- [x] My changes are minimal and accurately solve an identified problem
- [x] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] ~~I have updated the documentation accordingly~~
- [x] My changes generate no new warnings
