### PR TITLE
feat: Add multi-platform support for docker builds via buildx

### DIFF
--- a/Dockerfile-probe
+++ b/Dockerfile-probe
@@ -1,4 +1,4 @@
-FROM golang:1.24-alpine AS build
+FROM --platform=$BUILDPLATFORM golang:1.24-alpine AS build
 
 WORKDIR /
 
@@ -8,9 +8,12 @@ COPY [".", "."]
 # Download dependencies
 RUN ["go", "mod", "download"]
 
-# Build the probe binary
 ARG PROBE_IMAGE
-RUN env CGO_ENABLED=0 GOOS=linux go build -ldflags="-w -s -extldflags '-static' -X 'github.com/grafana/nethax/pkg/kubernetes.DefaultProbeImage=${PROBE_IMAGE}'" -a -o /probe ./cmd/probe
+#  Passed in from buildx
+ARG TARGETOS
+ARG TARGETARCH
+# Build the probe binary
+RUN env CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -ldflags="-w -s -extldflags '-static' -X 'github.com/grafana/nethax/pkg/kubernetes.DefaultProbeImage=${PROBE_IMAGE}'" -a -o /probe ./cmd/probe
 
 FROM scratch
 

--- a/Dockerfile-runner
+++ b/Dockerfile-runner
@@ -1,4 +1,4 @@
-FROM golang:1.24-alpine AS build
+FROM --platform=$BUILDPLATFORM golang:1.24-alpine AS build
 
 WORKDIR /
 
@@ -10,7 +10,11 @@ RUN ["go", "mod", "download"]
 
 # Build the probe binary
 ARG PROBE_IMAGE
-RUN env CGO_ENABLED=0 GOOS=linux go build -ldflags="-w -s -extldflags '-static' -X 'github.com/grafana/nethax/pkg/kubernetes.DefaultProbeImage=${PROBE_IMAGE}'" -a -o /runner ./cmd/runner
+#  Passed in from buildx
+ARG TARGETOS
+ARG TARGETARCH
+# Build the probe binary
+RUN env CGO_ENABLED=0 GOOS=${TARGETOS} GOARCH=${TARGETARCH} go build -ldflags="-w -s -extldflags '-static' -X 'github.com/grafana/nethax/pkg/kubernetes.DefaultProbeImage=${PROBE_IMAGE}'" -a -o /runner ./cmd/runner
 
 FROM scratch
 

--- a/Makefile
+++ b/Makefile
@@ -60,13 +60,21 @@ docker-push:
 	@docker push $(PROBE_IMAGE_PREFIX):latest
 
 docker-runner:
-	@docker build -f Dockerfile-runner --build-arg PROBE_IMAGE=$(PROBE_IMAGE_PREFIX):$(PROBE_VERSION) -t $(RUNNER_IMAGE_PREFIX):$(RUNNER_VERSION) -t $(RUNNER_IMAGE_PREFIX):latest .
+	@docker buildx build -f Dockerfile-runner \
+		--build-arg PROBE_IMAGE=$(PROBE_IMAGE_PREFIX):$(PROBE_VERSION) \
+		-t $(RUNNER_IMAGE_PREFIX):$(RUNNER_VERSION) -t $(RUNNER_IMAGE_PREFIX):latest \
+		--platform="linux/amd64,linux/arm64,linux/ppc64le,linux/s390x" \
+		.
 ifndef CI
 	@kind load docker-image --name $(KIND_CLUSTER_NAME) $(RUNNER_IMAGE_PREFIX):$(RUNNER_VERSION) || true
 endif
 
 docker-probe:
-	@docker build -f Dockerfile-probe --build-arg PROBE_IMAGE=$(PROBE_IMAGE_PREFIX):$(PROBE_VERSION) -t $(PROBE_IMAGE_PREFIX):$(PROBE_VERSION) -t $(PROBE_IMAGE_PREFIX):latest .
+	@docker buildx build -f Dockerfile-probe \
+		--build-arg PROBE_IMAGE=$(PROBE_IMAGE_PREFIX):$(PROBE_VERSION) \
+		-t $(PROBE_IMAGE_PREFIX):$(PROBE_VERSION) -t $(PROBE_IMAGE_PREFIX):latest \
+		--platform="linux/amd64,linux/arm64,linux/ppc64le,linux/s390x" \
+		.
 ifndef CI
 	@kind load docker-image --name $(KIND_CLUSTER_NAME) $(PROBE_IMAGE_PREFIX):$(PROBE_VERSION) || true
 endif


### PR DESCRIPTION
## Description
With the growing presence of Arm workloads in cloud environments, it's important to be able to run probes anywhere. This change adds buildx config and adds support to the dockerfile to build for various target platforms.

For now, we'll target the same platforms as alloy (https://github.com/grafana/alloy/blob/aadcc9ff59345cb00cb5c35c09e4f249c5c73a06/tools/ci/docker-containers\#L72).

## Changes
- Adds [support to Dockerfiles for buildx platform variables](https://docs.docker.com/build/building/multi-platform/#cross-compiling-a-go-application)
- Modifies Makefile to use buildx and pass in platforms (list of platforms taken from alloy)

## Testing
I ran `make docker-build` locally and it looked good 🚀 

## Special Considerations
You may need to enable the containerd image store if you haven't already:
https://docs.docker.com/engine/storage/containerd/

## Checklist
- [x] My changes are minimal and accurately solve an identified problem
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [ ] ~I have updated the documentation accordingly~
- [x] My changes generate no new warnings
