### PR TITLE
[nethax-probe]: Add DNS probe

### DIFF
--- a/cmd/nethax-probe/dns_probe.go
+++ b/cmd/nethax-probe/dns_probe.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"net"
+)
+
+type DNSProbe struct {
+	host string
+	fail bool
+	r    *net.Resolver
+}
+
+func NewDNSProbe(host string, fail bool) DNSProbe {
+	return DNSProbe{host: host, fail: fail}
+}
+
+func (p DNSProbe) Run(ctx context.Context) error {
+	if _, err := p.r.LookupHost(ctx, p.host); err != nil {
+		if p.fail {
+			return nil
+		}
+		return fmt.Errorf("%w: %w", errConnectionFailed, err)
+	}
+
+	if p.fail {
+		return fmt.Errorf("%w: %w", errAssertionFailed, errConnectionSucceeded)
+	}
+
+	return nil
+}

--- a/cmd/nethax-probe/dns_probe_test.go
+++ b/cmd/nethax-probe/dns_probe_test.go
@@ -34,7 +34,7 @@ func TestDNSProbe(t *testing.T) {
 	})
 
 	t.Run("probe should fail", func(t *testing.T) {
-		p := NewDNSProbe("example.com", true)
+		p := NewDNSProbe("nethax.grafana.com", true)
 
 		if err := p.Run(t.Context()); err != nil {
 			t.Fatalf("unexpected error %v", err)

--- a/cmd/nethax-probe/dns_probe_test.go
+++ b/cmd/nethax-probe/dns_probe_test.go
@@ -51,6 +51,14 @@ func TestDNSProbe(t *testing.T) {
 		}
 	})
 
+	t.Run("probe succeeds when it should fail", func(t *testing.T) {
+		p := NewDNSProbe("grafana.com", true)
+
+		if err := p.Run(t.Context()); err == nil {
+			t.Fatal("expecting error %w", errConnectionSucceeded)
+		}
+	})
+
 	t.Run("context aware", func(t *testing.T) {
 		p := NewDNSProbe("grafana.com", false)
 

--- a/cmd/nethax-probe/dns_probe_test.go
+++ b/cmd/nethax-probe/dns_probe_test.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+)
+
+func TestDNSProbe(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		t.Run("host resolves", func(t *testing.T) {
+			p := NewDNSProbe("grafana.com", false)
+
+			if err := p.Run(t.Context()); err != nil {
+				t.Fatal(err)
+			}
+		})
+
+		t.Run("host not found", func(t *testing.T) {
+			p := NewDNSProbe("example.com", true)
+
+			if err := p.Run(t.Context()); err != nil {
+				t.Fatal(err)
+			}
+		})
+	})
+
+	t.Run("conn should fail", func(t *testing.T) {
+		p := NewDNSProbe("grafana.com", false)
+
+		// TODO(inkel) this is a hack and should be done differently
+		p.r = &net.Resolver{
+			PreferGo: true,
+			Dial: func(ctx context.Context, network, address string) (net.Conn, error) {
+				return nil, errors.New("host not found")
+			},
+		}
+
+		if err := p.Run(t.Context()); !errors.Is(err, errConnectionFailed) {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("probe should fail", func(t *testing.T) {
+		p := NewDNSProbe("example.com", true)
+
+		if err := p.Run(t.Context()); err != nil {
+			t.Fatalf("unexoected error %v", err)
+		}
+	})
+
+	t.Run("context aware", func(t *testing.T) {
+		p := NewDNSProbe("grafana.com", false)
+
+		ctx, cancel := context.WithCancel(t.Context())
+		cancel()
+
+		if err := p.Run(ctx); !errors.Is(err, context.Canceled) {
+			t.Fatalf("expecting error %v, got %v", context.Canceled, err)
+		}
+	})
+}

--- a/cmd/nethax-probe/dns_probe_test.go
+++ b/cmd/nethax-probe/dns_probe_test.go
@@ -47,7 +47,7 @@ func TestDNSProbe(t *testing.T) {
 		p := NewDNSProbe("example.com", true)
 
 		if err := p.Run(t.Context()); err != nil {
-			t.Fatalf("unexoected error %v", err)
+			t.Fatalf("unexpected error %v", err)
 		}
 	})
 

--- a/cmd/nethax-probe/dns_probe_test.go
+++ b/cmd/nethax-probe/dns_probe_test.go
@@ -9,22 +9,12 @@ import (
 )
 
 func TestDNSProbe(t *testing.T) {
-	t.Run("success", func(t *testing.T) {
-		t.Run("host resolves", func(t *testing.T) {
-			p := NewDNSProbe("grafana.com", false)
+	t.Run("host resolves", func(t *testing.T) {
+		p := NewDNSProbe("grafana.com", false)
 
-			if err := p.Run(t.Context()); err != nil {
-				t.Fatal(err)
-			}
-		})
-
-		t.Run("host not found", func(t *testing.T) {
-			p := NewDNSProbe("example.com", true)
-
-			if err := p.Run(t.Context()); err != nil {
-				t.Fatal(err)
-			}
-		})
+		if err := p.Run(t.Context()); err != nil {
+			t.Fatal(err)
+		}
 	})
 
 	t.Run("conn should fail", func(t *testing.T) {

--- a/cmd/nethax-probe/dns_probe_test.go
+++ b/cmd/nethax-probe/dns_probe_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net"
+	"strings"
 	"testing"
 )
 
@@ -56,7 +57,11 @@ func TestDNSProbe(t *testing.T) {
 		ctx, cancel := context.WithCancel(t.Context())
 		cancel()
 
-		if err := p.Run(ctx); !errors.Is(err, context.Canceled) {
+		// This should be !errors.Is(err, context.Canceled) but there
+		// seems to be a bug in Go stdlib, check
+		// https://github.com/golang/go/issues/71939 for additional
+		// information.
+		if err := p.Run(ctx); !strings.Contains(err.Error(), "operation was canceled") {
 			t.Fatalf("expecting error %v, got %v", context.Canceled, err)
 		}
 	})

--- a/cmd/nethax-probe/main.go
+++ b/cmd/nethax-probe/main.go
@@ -29,7 +29,7 @@ func main() {
 	flag.DurationVar(&timeout, pf.ArgTimeout, 5*time.Second, "Timeout value (e.g. 5s, 1m)")
 	flag.IntVar(&expectedStatus, pf.ArgExpectedStatus, 200, "Expected HTTP status code (0 for connection failure)")
 	flag.StringVar(&testType, pf.ArgType, pf.TestTypeHTTP, "Type of test (http or tcp)")
-	flag.BoolVar(&expectFail, pf.ArgExpectFail, false, "Whether the test is expected to fail (TCP tests only)")
+	flag.BoolVar(&expectFail, pf.ArgExpectFail, false, "Whether the test is expected to fail (TCP and DNS tests only)")
 	flag.Parse()
 
 	if url == "" {
@@ -44,6 +44,8 @@ func main() {
 		probe = NewTCPProbe(url, expectFail)
 	case pf.TestTypeHTTP:
 		probe = NewHTTPProbe(url, expectedStatus)
+	case pf.TestTypeDNS:
+		probe = NewDNSProbe(url, expectFail)
 	default:
 		fmt.Println("Error: Invalid test type: ", testType)
 		os.Exit(exitCodeConfigError)

--- a/cmd/nethax/testplan.go
+++ b/cmd/nethax/testplan.go
@@ -80,6 +80,8 @@ func (tt TestType) String() string {
 		return "http"
 	case TestTypeTCP:
 		return "tcp"
+	case TestTypeDNS:
+		return "dns"
 	default:
 		panic("unrecognized testype")
 	}
@@ -88,6 +90,7 @@ func (tt TestType) String() string {
 const (
 	TestTypeHTTP TestType = iota
 	TestTypeTCP
+	TestTypeDNS
 )
 
 var errInvalidTestType = errors.New("invalid test type")
@@ -98,6 +101,8 @@ func yamlUnmarshalTestType(tt *TestType, b []byte) error {
 		*tt = TestTypeHTTP
 	case "tcp":
 		*tt = TestTypeTCP
+	case "dns":
+		*tt = TestTypeDNS
 	default:
 		return fmt.Errorf("%w: %q", errInvalidTestType, b)
 	}

--- a/cmd/nethax/testplan_test.go
+++ b/cmd/nethax/testplan_test.go
@@ -99,10 +99,12 @@ func TestTestType_UnmarshalYAML(t *testing.T) {
 		"http":  {TestTypeHTTP, nil},
 		"https": {TestTypeHTTP, nil},
 		"tcp":   {TestTypeTCP, nil},
+		"dns":   {TestTypeDNS, nil},
 		// ignore case
 		"HTTP":  {TestTypeHTTP, nil},
 		"HTTPS": {TestTypeHTTP, nil},
 		"TCP":   {TestTypeTCP, nil},
+		"DNS":   {TestTypeDNS, nil},
 		// invalid values // TODO(inkel) this could probably be a fuzz test
 		"foo": {TestTypeHTTP, errInvalidTestType},
 	}

--- a/example/OtelDemoTestPlan.yaml
+++ b/example/OtelDemoTestPlan.yaml
@@ -31,3 +31,7 @@ testPlan:
       type: tcp
       expectFail: true # TCP connection failure is expected; useful to test network policies
       timeout: 3s
+    - name: "DNS resolves"
+      endpoint: "grafana.com"
+      type: dns
+      timeout: 50ms

--- a/pkg/probeflags/probeflags.go
+++ b/pkg/probeflags/probeflags.go
@@ -18,4 +18,5 @@ func Flagify(flag string) string {
 const (
 	TestTypeTCP  = "tcp"
 	TestTypeHTTP = "http"
+	TestTypeDNS  = "dns"
 )


### PR DESCRIPTION
## Description
This PR adds a new DNS kind probe that allows checking if resolving a domain name works.

## Changes
* Add `DNSProbe` type.
* Add `-type=dns` flag option.

## Testing
Added test suite.

## Special Considerations
Note that there's a hack to test the context aware requisite of a probe, probably related with [this issue](https://github.com/golang/go/issues/71939).

## Checklist
- [x] My changes are minimal and accurately solve an identified problem
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have updated the documentation accordingly
- [x] My changes generate no new warnings
