### PR TITLE
Change Renovate schedule for grafana/sharedworkflows

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,5 +6,16 @@
   "postUpdateOptions": [
     "gomodTidy"
   ],
+  "packageRules": [
+    {
+      "description": "Schedule grafana/shared-workflows updates on Sunday nights (9 PM - 12 AM)",
+      "matchPackageNames": [
+        "@grafana/shared-workflows/*"
+      ],
+      "schedule": [
+        "* 21-23 * * 0"
+      ]
+    }
+  ],
   "automerge": true
 }


### PR DESCRIPTION
This dependency gets updated very frequently, triggering Renovate to create a PR almost on a daily basis, but the action that we use, at the time of writing this, hasn't been updated in 2 months. I couldn't use the tag for this action as Zizmor complains that we are not using a hash, and we would like to keep updating this eventually, so let's change the frequency at which Renovate updates this action to once a week instead.